### PR TITLE
feat: add kamis monthly feign client

### DIFF
--- a/apps/dragons_api/src/main/java/com/dragons/Application.java
+++ b/apps/dragons_api/src/main/java/com/dragons/Application.java
@@ -1,9 +1,12 @@
 package com.dragons;
 
+import client.KamisFeignClient;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackageClasses = KamisFeignClient.class)
 public class Application {
 
   public static void main(String[] args) {

--- a/infra/feign/build.gradle
+++ b/infra/feign/build.gradle
@@ -3,7 +3,8 @@ plugins {
 }
 
 dependencies {
-    api 'io.github.openfeign:feign-core:13.5'
+    api 'org.springframework.cloud:spring-cloud-starter-openfeign:5.0.1'
+    implementation project(':infra:jackson')
     implementation 'org.springframework.boot:spring-boot-starter'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/infra/feign/src/main/java/client/KamisFeignClient.java
+++ b/infra/feign/src/main/java/client/KamisFeignClient.java
@@ -1,0 +1,25 @@
+package client;
+
+import config.FeignConfig;
+import dto.KamisMonthlyPriceResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "kamisFeignClient",
+    url = "${kamis.api.base-url}",
+    configuration = FeignConfig.class)
+public interface KamisFeignClient {
+
+  @GetMapping(value = "/service/price/xml.do", produces = "application/json")
+  KamisMonthlyPriceResponse fetchMonthlyPricesInternal(
+      @RequestParam("action") String requestAction,
+      @RequestParam("p_returntype") String responseFormat,
+      @RequestParam("p_cert_key") String certificationKey,
+      @RequestParam("p_cert_id") String certificationId,
+      @RequestParam("p_yyyy") String targetYear,
+      @RequestParam("p_mm") String targetMonth,
+      @RequestParam("p_item_category_code") String itemCategoryCode
+  );
+}

--- a/infra/feign/src/main/java/config/FeignConfig.java
+++ b/infra/feign/src/main/java/config/FeignConfig.java
@@ -37,7 +37,6 @@ public class FeignConfig {
         .logger(new RequestResponseLoggingLogger());
   }
 
-
   @Bean
   public Feign.Builder feignBuilder(
       FeignProperties properties) {

--- a/infra/feign/src/main/java/dto/KamisMonthlyPriceResponse.java
+++ b/infra/feign/src/main/java/dto/KamisMonthlyPriceResponse.java
@@ -1,0 +1,36 @@
+package dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KamisMonthlyPriceResponse(
+    KamisMonthlyPriceData data
+) {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record KamisMonthlyPriceData(
+      List<KamisMonthlyPriceItem> item
+  ) {
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record KamisMonthlyPriceItem(
+      @JsonProperty("itemcode") String itemCode,
+      @JsonProperty("item_name") String itemName,
+      @JsonProperty("kindcode") String kindCode,
+      @JsonProperty("kind_name") String kindName,
+      @JsonProperty("market_code") String marketCode,
+      @JsonProperty("marketname") String marketName,
+      @JsonProperty("rank_code") String rankCode,
+      @JsonProperty("rank") String rankName,
+      String unit,
+      String day1,
+      String dpr1,
+      String day2,
+      String dpr2,
+      @JsonProperty("product_cls_code") String productClsCode
+  ) {
+  }
+}

--- a/infra/feign/src/main/java/interceptor/RequestResponseLoggingLogger.java
+++ b/infra/feign/src/main/java/interceptor/RequestResponseLoggingLogger.java
@@ -10,13 +10,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 @Slf4j
 public class RequestResponseLoggingLogger extends Logger {
-
-
 
   @Override
   protected void log(String configKey, String format, Object... args) {
@@ -26,7 +23,6 @@ public class RequestResponseLoggingLogger extends Logger {
   @Override
   protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime)
       throws IOException {
-
 
     Request request = response.request();
     byte[] responseBody = readResponseBody(response);

--- a/infra/feign/src/main/resources/kamis.yml
+++ b/infra/feign/src/main/resources/kamis.yml
@@ -1,5 +1,6 @@
 kamis:
   api:
+    base-url: https://www.kamis.or.kr
     cert-key: ${CERT_KEY}
     cert-id: ${CERT_ID}
     mock-mode: false

--- a/infra/feign/src/test/java/client/KamisFeignClientTest.java
+++ b/infra/feign/src/test/java/client/KamisFeignClientTest.java
@@ -1,0 +1,18 @@
+package client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dto.KamisMonthlyPriceResponse;
+import java.lang.reflect.RecordComponent;
+import org.junit.jupiter.api.Test;
+
+class KamisFeignClientTest {
+
+  @Test
+  void monthlyPriceResponseUsesTypedRecordsInsteadOfMap() {
+    RecordComponent[] components = KamisMonthlyPriceResponse.KamisMonthlyPriceItem.class.getRecordComponents();
+
+    assertThat(components).extracting(RecordComponent::getName)
+        .contains("itemCode", "itemName", "kindCode", "marketCode", "dpr1", "productClsCode");
+  }
+}


### PR DESCRIPTION
## 요약
- KAMIS monthlySalesList 호출용 OpenFeign 클라이언트를 추가했습니다.
- monthly 응답 DTO를 typed record로 정의하고 camelCase 필드명으로 정리했습니다.
- apps 쪽에서 Feign client 스캔이 되도록 설정을 추가했습니다.

## 변경 사항
- `infra/feign`에 `KamisFeignClient` 추가
- `infra/feign`에 `KamisMonthlyPriceResponse` DTO 추가
- `infra:feign`이 `infra:jackson`을 사용하도록 의존 정리
- `apps/dragons_api`에 `@EnableFeignClients` 추가
- Feign 관련 테스트 추가/정리

## 검증
- `./gradlew :infra:feign:test`
- `./gradlew :infra:feign:test :apps:dragons_api:test`

## 이슈 연결
- Closes #2
