### PR TITLE
월별 가격 조회 배치와 run-monthly 엔드포인트를 추가한다

### DIFF
--- a/apps/batch-core/src/main/java/com/application/BatchManualRunService.java
+++ b/apps/batch-core/src/main/java/com/application/BatchManualRunService.java
@@ -6,24 +6,35 @@ import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class BatchManualRunService {
 
   private final JobOperator jobOperator;
   private final Job kamisPriceJob;
   private final JdbcTemplate jdbcTemplate;
   private final Clock clock;
+
+  public BatchManualRunService(
+      JobOperator jobOperator,
+      @Qualifier("kamisPriceJob") Job kamisPriceJob,
+      JdbcTemplate jdbcTemplate,
+      Clock clock
+  ) {
+    this.jobOperator = jobOperator;
+    this.kamisPriceJob = kamisPriceJob;
+    this.jdbcTemplate = jdbcTemplate;
+    this.clock = clock;
+  }
 
   public BatchRunResult run(String itemCategoryCode, LocalDate regDay) {
     try {

--- a/apps/batch-core/src/main/java/com/application/BatchMonthlyRunService.java
+++ b/apps/batch-core/src/main/java/com/application/BatchMonthlyRunService.java
@@ -1,0 +1,66 @@
+package com.application;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BatchMonthlyRunService {
+
+  private final JobOperator jobOperator;
+  private final Job kamisMonthlyPriceJob;
+  private final Clock clock;
+
+  public BatchMonthlyRunService(
+      JobOperator jobOperator,
+      @Qualifier("kamisMonthlyPriceJob") Job kamisMonthlyPriceJob,
+      Clock clock
+  ) {
+    this.jobOperator = jobOperator;
+    this.kamisMonthlyPriceJob = kamisMonthlyPriceJob;
+    this.clock = clock;
+  }
+
+  public BatchRunResult run(String itemCategoryCode, YearMonth yearMonth) {
+    try {
+      JobExecution jobExecution = jobOperator.start(
+          kamisMonthlyPriceJob,
+          new JobParametersBuilder()
+              .addString("itemCategoryCode", itemCategoryCode)
+              .addString("yyyy", String.valueOf(yearMonth.getYear()))
+              .addString("mm", "%02d".formatted(yearMonth.getMonthValue()))
+              .addLong("requestedAt", clock.millis())
+              .toJobParameters()
+      );
+
+      if (jobExecution.getStatus() != BatchStatus.COMPLETED) {
+        throw new IllegalStateException(
+            "월별 배치 실행에 실패했습니다.",
+            jobExecution.getAllFailureExceptions().stream().findFirst().orElse(null)
+        );
+      }
+
+      return new BatchRunResult(
+          jobExecution.getId(),
+          jobExecution.getStatus().name(),
+          jobExecution.getStartTime(),
+          jobExecution.getEndTime(),
+          jobExecution.getStepExecutions().stream()
+              .mapToLong(StepExecution::getWriteCount)
+              .sum()
+      );
+    } catch (IllegalStateException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalStateException("월별 배치 실행에 실패했습니다.", exception);
+    }
+  }
+}

--- a/apps/batch-core/src/main/java/com/application/MonthlyPriceReadService.java
+++ b/apps/batch-core/src/main/java/com/application/MonthlyPriceReadService.java
@@ -1,0 +1,19 @@
+package com.application;
+
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import model.price.MonthlyPriceReader;
+import model.price.PriceReadItem;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyPriceReadService {
+
+  private final MonthlyPriceReader monthlyPriceReader;
+
+  public List<PriceReadItem> readItems(String itemCategoryCode, YearMonth yearMonth) {
+    return monthlyPriceReader.readInMonth(itemCategoryCode, yearMonth);
+  }
+}

--- a/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
+++ b/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
@@ -1,11 +1,14 @@
 package com.config;
 
+import com.application.MonthlyPriceReadService;
 import com.application.PriceReadService;
 import com.process.KamisItemProcessor;
 import com.read.KamisItemReader;
+import com.read.KamisMonthlyItemReader;
 import com.write.KamisItemWriter;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import model.price.PriceData;
 import model.price.PriceDataRepository;
 import model.price.PriceReadItem;
@@ -19,6 +22,7 @@ import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -48,6 +52,25 @@ public class BatchCoreConfiguration {
   }
 
   @Bean
+  @StepScope
+  ItemReader<PriceReadItem> kamisMonthlyItemReader(
+      MonthlyPriceReadService monthlyPriceReadService,
+      @Value("#{jobParameters['itemCategoryCode']}") String itemCategoryCode,
+      @Value("#{jobParameters['yyyy']}") String yyyy,
+      @Value("#{jobParameters['mm']}") String mm
+  ) {
+    YearMonth yearMonth = (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank())
+        ? YearMonth.now()
+        : YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+
+    return new KamisMonthlyItemReader(
+        monthlyPriceReadService,
+        itemCategoryCode == null || itemCategoryCode.isBlank() ? "200" : itemCategoryCode,
+        yearMonth
+    );
+  }
+
+  @Bean
   ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor(Clock batchClock) {
     return new KamisItemProcessor(batchClock);
   }
@@ -61,7 +84,7 @@ public class BatchCoreConfiguration {
   Step kamisPriceStep(
       JobRepository jobRepository,
       PlatformTransactionManager transactionManager,
-      ItemReader<PriceReadItem> kamisItemReader,
+      @Qualifier("kamisItemReader") ItemReader<PriceReadItem> kamisItemReader,
       ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor,
       ItemWriter<PriceData> kamisItemWriter
   ) {
@@ -75,9 +98,36 @@ public class BatchCoreConfiguration {
   }
 
   @Bean
-  Job kamisPriceJob(JobRepository jobRepository, Step kamisPriceStep) {
+  Job kamisPriceJob(JobRepository jobRepository, @Qualifier("kamisPriceStep") Step kamisPriceStep) {
     return new JobBuilder("kamisPriceJob", jobRepository)
         .start(kamisPriceStep)
+        .build();
+  }
+
+  @Bean
+  Step kamisMonthlyPriceStep(
+      JobRepository jobRepository,
+      PlatformTransactionManager transactionManager,
+      @Qualifier("kamisMonthlyItemReader") ItemReader<PriceReadItem> kamisMonthlyItemReader,
+      ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor,
+      ItemWriter<PriceData> kamisItemWriter
+  ) {
+    return new StepBuilder("kamisMonthlyPriceStep", jobRepository)
+        .<PriceReadItem, PriceData>chunk(CHUNK_SIZE)
+        .transactionManager(transactionManager)
+        .reader(kamisMonthlyItemReader)
+        .processor(kamisItemProcessor)
+        .writer(kamisItemWriter)
+        .build();
+  }
+
+  @Bean
+  Job kamisMonthlyPriceJob(
+      JobRepository jobRepository,
+      @Qualifier("kamisMonthlyPriceStep") Step kamisMonthlyPriceStep
+  ) {
+    return new JobBuilder("kamisMonthlyPriceJob", jobRepository)
+        .start(kamisMonthlyPriceStep)
         .build();
   }
 }

--- a/apps/batch-core/src/main/java/com/read/KamisMonthlyItemReader.java
+++ b/apps/batch-core/src/main/java/com/read/KamisMonthlyItemReader.java
@@ -1,0 +1,33 @@
+package com.read;
+
+import com.application.MonthlyPriceReadService;
+import java.time.YearMonth;
+import java.util.Iterator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import model.price.PriceReadItem;
+import org.springframework.batch.infrastructure.item.ItemReader;
+
+@RequiredArgsConstructor
+public class KamisMonthlyItemReader implements ItemReader<PriceReadItem> {
+
+  private final MonthlyPriceReadService monthlyPriceReadService;
+  private final String itemCategoryCode;
+  private final YearMonth yearMonth;
+
+  private Iterator<PriceReadItem> iterator;
+
+  @Override
+  public PriceReadItem read() {
+    if (iterator == null) {
+      List<PriceReadItem> items = monthlyPriceReadService.readItems(itemCategoryCode, yearMonth);
+      iterator = items.iterator();
+    }
+
+    if (!iterator.hasNext()) {
+      return null;
+    }
+
+    return iterator.next();
+  }
+}

--- a/apps/batch-core/src/test/java/com/application/BatchMonthlyRunServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/BatchMonthlyRunServiceTest.java
@@ -1,0 +1,82 @@
+package com.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.step.StepExecution;
+
+class BatchMonthlyRunServiceTest {
+
+  @Test
+  void runLaunchesMonthlyJobWithRequestParametersAndReturnsExecutionSummary() throws Exception {
+    JobOperator jobOperator = mock(JobOperator.class);
+    Job kamisMonthlyPriceJob = mock(Job.class);
+    Clock clock = Clock.fixed(Instant.parse("2026-04-21T00:00:00Z"), ZoneOffset.UTC);
+    JobExecution jobExecution = mock(JobExecution.class);
+    StepExecution stepExecution = mock(StepExecution.class);
+    BatchMonthlyRunService batchMonthlyRunService = new BatchMonthlyRunService(jobOperator, kamisMonthlyPriceJob, clock);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(jobOperator.start(eq(kamisMonthlyPriceJob), org.mockito.ArgumentMatchers.any(JobParameters.class)))
+        .willReturn(jobExecution);
+    given(jobExecution.getStatus()).willReturn(BatchStatus.COMPLETED);
+    given(jobExecution.getId()).willReturn(41L);
+    given(jobExecution.getStartTime()).willReturn(LocalDateTime.of(2024, 1, 31, 10, 0));
+    given(jobExecution.getEndTime()).willReturn(LocalDateTime.of(2024, 1, 31, 10, 1));
+    given(jobExecution.getStepExecutions()).willReturn(Set.of(stepExecution));
+    given(stepExecution.getWriteCount()).willReturn(4L);
+
+    BatchRunResult result = batchMonthlyRunService.run("200", yearMonth);
+
+    ArgumentCaptor<JobParameters> jobParametersCaptor = ArgumentCaptor.forClass(JobParameters.class);
+    then(jobOperator).should().start(eq(kamisMonthlyPriceJob), jobParametersCaptor.capture());
+
+    JobParameters jobParameters = jobParametersCaptor.getValue();
+    assertThat(jobParameters.getString("itemCategoryCode")).isEqualTo("200");
+    assertThat(jobParameters.getString("yyyy")).isEqualTo("2024");
+    assertThat(jobParameters.getString("mm")).isEqualTo("01");
+    assertThat(jobParameters.getLong("requestedAt")).isEqualTo(clock.millis());
+
+    assertThat(result.jobExecutionId()).isEqualTo(41L);
+    assertThat(result.status()).isEqualTo("COMPLETED");
+    assertThat(result.writeCount()).isEqualTo(4);
+  }
+
+  @Test
+  void runThrowsWhenMonthlyBatchExecutionFails() throws Exception {
+    JobOperator jobOperator = mock(JobOperator.class);
+    Job kamisMonthlyPriceJob = mock(Job.class);
+    Clock clock = Clock.fixed(Instant.parse("2026-04-21T00:00:00Z"), ZoneOffset.UTC);
+    JobExecution jobExecution = mock(JobExecution.class);
+    BatchMonthlyRunService batchMonthlyRunService = new BatchMonthlyRunService(jobOperator, kamisMonthlyPriceJob, clock);
+    RuntimeException failure = new RuntimeException("monthly writer failed");
+
+    given(jobOperator.start(eq(kamisMonthlyPriceJob), org.mockito.ArgumentMatchers.any(JobParameters.class)))
+        .willReturn(jobExecution);
+    given(jobExecution.getStatus()).willReturn(BatchStatus.FAILED);
+    given(jobExecution.getAllFailureExceptions()).willReturn(List.of(failure));
+
+    assertThatThrownBy(() -> batchMonthlyRunService.run("200", YearMonth.of(2024, 1)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("월별 배치 실행에 실패했습니다.")
+        .hasRootCause(failure);
+  }
+}

--- a/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
@@ -1,0 +1,29 @@
+package com.application.monthly;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.application.MonthlyPriceReadService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import model.price.MonthlyPriceReader;
+import model.price.PriceReadItem;
+import org.junit.jupiter.api.Test;
+
+class MonthlyPriceReadServiceTest {
+
+  @Test
+  void readItemsDelegatesToMonthlyReader() {
+    MonthlyPriceReader monthlyPriceReader = org.mockito.Mockito.mock(MonthlyPriceReader.class);
+    MonthlyPriceReadService monthlyPriceReadService = new MonthlyPriceReadService(monthlyPriceReader);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+    List<PriceReadItem> expected = List.of(
+        new PriceReadItem("111", "배추", "01", "일반", "100", "서울", "01", "상품", 12000, "10kg", LocalDate.of(2024, 1, 15))
+    );
+
+    given(monthlyPriceReader.readInMonth("200", yearMonth)).willReturn(expected);
+
+    assertThat(monthlyPriceReadService.readItems("200", yearMonth)).isEqualTo(expected);
+  }
+}

--- a/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
@@ -2,6 +2,7 @@ package com.application.monthly;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.application.MonthlyPriceReadService;
 import java.time.LocalDate;
@@ -15,7 +16,7 @@ class MonthlyPriceReadServiceTest {
 
   @Test
   void readItemsDelegatesToMonthlyReader() {
-    MonthlyPriceReader monthlyPriceReader = org.mockito.Mockito.mock(MonthlyPriceReader.class);
+    MonthlyPriceReader monthlyPriceReader = mock(MonthlyPriceReader.class);
     MonthlyPriceReadService monthlyPriceReadService = new MonthlyPriceReadService(monthlyPriceReader);
     YearMonth yearMonth = YearMonth.of(2024, 1);
     List<PriceReadItem> expected = List.of(

--- a/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
+++ b/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
@@ -1,0 +1,34 @@
+package com.read;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.application.MonthlyPriceReadService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import model.price.PriceReadItem;
+import org.junit.jupiter.api.Test;
+
+class KamisMonthlyItemReaderTest {
+
+  @Test
+  void readReturnsMonthlyItemsInOrderAndThenNull() {
+    MonthlyPriceReadService monthlyPriceReadService = org.mockito.Mockito.mock(MonthlyPriceReadService.class);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(monthlyPriceReadService.readItems("200", yearMonth))
+        .willReturn(
+            List.of(
+                new PriceReadItem("111", "배추", "01", "일반", "100", "서울", "01", "상품", 12000, "10kg", LocalDate.of(2024, 1, 15)),
+                new PriceReadItem("112", "무", "01", "일반", "100", "서울", "01", "상품", 9800, "20kg", LocalDate.of(2024, 1, 16))
+            )
+        );
+
+    KamisMonthlyItemReader reader = new KamisMonthlyItemReader(monthlyPriceReadService, "200", yearMonth);
+
+    assertThat(reader.read().itemCode()).isEqualTo("111");
+    assertThat(reader.read().itemCode()).isEqualTo("112");
+    assertThat(reader.read()).isNull();
+  }
+}

--- a/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
+++ b/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
@@ -2,6 +2,9 @@ package com.read;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.application.MonthlyPriceReadService;
 import java.time.LocalDate;
@@ -14,7 +17,7 @@ class KamisMonthlyItemReaderTest {
 
   @Test
   void readReturnsMonthlyItemsInOrderAndThenNull() {
-    MonthlyPriceReadService monthlyPriceReadService = org.mockito.Mockito.mock(MonthlyPriceReadService.class);
+    MonthlyPriceReadService monthlyPriceReadService = mock(MonthlyPriceReadService.class);
     YearMonth yearMonth = YearMonth.of(2024, 1);
 
     given(monthlyPriceReadService.readItems("200", yearMonth))
@@ -30,5 +33,19 @@ class KamisMonthlyItemReaderTest {
     assertThat(reader.read().itemCode()).isEqualTo("111");
     assertThat(reader.read().itemCode()).isEqualTo("112");
     assertThat(reader.read()).isNull();
+    verify(monthlyPriceReadService, times(1)).readItems("200", yearMonth);
+  }
+
+  @Test
+  void readReturnsNullImmediatelyWhenMonthlyItemsAreEmpty() {
+    MonthlyPriceReadService monthlyPriceReadService = mock(MonthlyPriceReadService.class);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(monthlyPriceReadService.readItems("200", yearMonth)).willReturn(List.of());
+
+    KamisMonthlyItemReader reader = new KamisMonthlyItemReader(monthlyPriceReadService, "200", yearMonth);
+
+    assertThat(reader.read()).isNull();
+    verify(monthlyPriceReadService, times(1)).readItems("200", yearMonth);
   }
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -64,7 +64,7 @@ public class BatchApiController {
   @Operation(summary = "월별 배치 수동 실행")
   public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@Valid @ModelAttribute BatchMonthlyRunRequest request) {
     String itemCategoryCode = resolveItemCategoryCode(request.itemCategoryCode());
-    YearMonth targetYearMonth = resolveYearMonth(request.yyyy(), request.mm());
+    YearMonth targetYearMonth = resolveYearMonth(request.year(), request.month());
     BatchRunResult result = batchMonthlyRunService.run(itemCategoryCode, targetYearMonth);
 
     return ApiResponse.successResponse(

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -1,9 +1,12 @@
 package com.dragons.interfaces.api.batch;
 
+import com.application.BatchMonthlyRunService;
 import com.application.BatchManualRunService;
 import com.application.BatchRunResult;
 import com.application.BatchStatusResult;
 import com.dragons.interfaces.api.batch.dto.BatchConfigResponse;
+import com.dragons.interfaces.api.batch.dto.BatchMonthlyRunRequest;
+import com.dragons.interfaces.api.batch.dto.BatchMonthlyRunResponse;
 import com.dragons.interfaces.api.batch.dto.BatchRunRequest;
 import com.dragons.interfaces.api.batch.dto.BatchRunResponse;
 import com.dragons.interfaces.api.batch.dto.BatchStatusItemResponse;
@@ -15,6 +18,7 @@ import constant.Constants;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BatchApiController {
 
+  private final BatchMonthlyRunService batchMonthlyRunService;
   private final BatchManualRunService batchManualRunService;
   private final MarketPriceApiProperties marketPriceApiProperties;
 
@@ -52,18 +57,44 @@ public class BatchApiController {
     ));
   }
 
+  @PostMapping("/run-monthly")
+  @Operation(summary = "월별 배치 수동 실행")
+  public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@ModelAttribute BatchMonthlyRunRequest request) {
+    String itemCategoryCode = resolveItemCategoryCode(request.itemCategoryCode());
+    YearMonth targetYearMonth = resolveYearMonth(request.yyyy(), request.mm());
+    BatchRunResult result = batchMonthlyRunService.run(itemCategoryCode, targetYearMonth);
+
+    return ApiResponse.successResponse(
+        new BatchMonthlyRunResponse(
+            result.jobExecutionId(),
+            result.status(),
+            formatDateTime(result.startTime()),
+            formatDateTime(result.endTime()),
+            itemCategoryCode,
+            String.valueOf(targetYearMonth.getYear()),
+            "%02d".formatted(targetYearMonth.getMonthValue()),
+            marketPriceApiProperties.isMockMode()
+        )
+    );
+  }
+
   @GetMapping("/status")
   @Operation(summary = "배치 실행 이력 조회")
   public ApiResponse<BatchStatusResponse> getBatchStatus(@ModelAttribute BatchStatusRequest request) {
     BatchStatusResult result = batchManualRunService.latestStatuses(request.resolvedLimit());
+    boolean certKeySet = hasConcreteValue(marketPriceApiProperties.getCertKey());
+    boolean certIdSet = hasConcreteValue(marketPriceApiProperties.getCertId());
+    boolean mockMode = marketPriceApiProperties.isMockMode();
+
     return ApiResponse.successResponse(
         new BatchStatusResponse(
             result.count(),
-            false,
-            false,
+            mockMode,
+            certKeySet && certIdSet && !mockMode,
             result.items().stream()
                 .map(item -> new BatchStatusItemResponse(
                     item.jobInstanceId(),
+                    item.jobExecutionId(),
                     item.jobName(),
                     item.status(),
                     formatDateTime(item.startTime()),
@@ -95,15 +126,24 @@ public class BatchApiController {
   }
 
   private String resolveItemCategoryCode(BatchRunRequest request) {
-    return request.itemCategoryCode() == null || request.itemCategoryCode().isBlank()
-        ? "200"
-        : request.itemCategoryCode();
+    return resolveItemCategoryCode(request.itemCategoryCode());
+  }
+
+  private String resolveItemCategoryCode(String itemCategoryCode) {
+    return itemCategoryCode == null || itemCategoryCode.isBlank() ? "200" : itemCategoryCode;
   }
 
   private String resolveRegDay(BatchRunRequest request) {
     return request.regDay() == null || request.regDay().isBlank()
         ? LocalDate.now().toString()
         : request.regDay();
+  }
+
+  private YearMonth resolveYearMonth(String yyyy, String mm) {
+    if (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank()) {
+      return YearMonth.now();
+    }
+    return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
   }
 
   private String formatDateTime(java.time.LocalDateTime value) {

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -1,7 +1,7 @@
 package com.dragons.interfaces.api.batch;
 
-import com.application.BatchMonthlyRunService;
 import com.application.BatchManualRunService;
+import com.application.BatchMonthlyRunService;
 import com.application.BatchRunResult;
 import com.application.BatchStatusResult;
 import com.dragons.interfaces.api.batch.dto.BatchConfigResponse;
@@ -17,15 +17,18 @@ import com.properties.MarketPriceApiProperties;
 import constant.Constants;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/batch")
@@ -59,7 +62,7 @@ public class BatchApiController {
 
   @PostMapping("/run-monthly")
   @Operation(summary = "월별 배치 수동 실행")
-  public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@ModelAttribute BatchMonthlyRunRequest request) {
+  public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@Valid @ModelAttribute BatchMonthlyRunRequest request) {
     String itemCategoryCode = resolveItemCategoryCode(request.itemCategoryCode());
     YearMonth targetYearMonth = resolveYearMonth(request.yyyy(), request.mm());
     BatchRunResult result = batchMonthlyRunService.run(itemCategoryCode, targetYearMonth);
@@ -140,10 +143,21 @@ public class BatchApiController {
   }
 
   private YearMonth resolveYearMonth(String yyyy, String mm) {
-    if (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank()) {
+    boolean yyyyProvided = yyyy != null && !yyyy.isBlank();
+    boolean mmProvided = mm != null && !mm.isBlank();
+
+    if (!yyyyProvided && !mmProvided) {
       return YearMonth.now();
     }
-    return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+    if (yyyyProvided != mmProvided) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "yyyy와 mm은 함께 입력해야 합니다.");
+    }
+
+    try {
+      return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+    } catch (NumberFormatException | DateTimeException exception) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "yyyy/mm 형식이 올바르지 않습니다.", exception);
+    }
   }
 
   private String formatDateTime(java.time.LocalDateTime value) {

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -1,0 +1,8 @@
+package com.dragons.interfaces.api.batch.dto;
+
+public record BatchMonthlyRunRequest(
+    String itemCategoryCode,
+    String yyyy,
+    String mm
+) {
+}

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -7,9 +7,9 @@ public record BatchMonthlyRunRequest(
     @NotBlank(message = "itemCategoryCode는 필수입니다.") String itemCategoryCode,
     @NotBlank(message = "yyyy는 필수입니다.")
     @Pattern(regexp = "\\d{4}", message = "yyyy는 4자리 연도여야 합니다.")
-    String yyyy,
+    String year,
     @NotBlank(message = "mm는 필수입니다.")
     @Pattern(regexp = "(0[1-9]|1[0-2])", message = "mm는 01~12 형식이어야 합니다.")
-    String mm
+    String month
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -1,8 +1,15 @@
 package com.dragons.interfaces.api.batch.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record BatchMonthlyRunRequest(
-    String itemCategoryCode,
+    @NotBlank(message = "itemCategoryCode는 필수입니다.") String itemCategoryCode,
+    @NotBlank(message = "yyyy는 필수입니다.")
+    @Pattern(regexp = "\\d{4}", message = "yyyy는 4자리 연도여야 합니다.")
     String yyyy,
+    @NotBlank(message = "mm는 필수입니다.")
+    @Pattern(regexp = "(0[1-9]|1[0-2])", message = "mm는 01~12 형식이어야 합니다.")
     String mm
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
@@ -6,8 +6,8 @@ public record BatchMonthlyRunResponse(
     String startTime,
     String endTime,
     String itemCategoryCode,
-    String yyyy,
-    String mm,
+    String year,
+    String month,
     boolean mockMode
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
@@ -1,0 +1,13 @@
+package com.dragons.interfaces.api.batch.dto;
+
+public record BatchMonthlyRunResponse(
+    long jobExecutionId,
+    String status,
+    String startTime,
+    String endTime,
+    String itemCategoryCode,
+    String yyyy,
+    String mm,
+    boolean mockMode
+) {
+}

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchStatusItemResponse.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchStatusItemResponse.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 public record BatchStatusItemResponse(
     long jobInstanceId,
+    long jobExecutionId,
     String jobName,
     String status,
     String startTime,

--- a/apps/dragons_api/src/main/java/com/dragons/support/error/GlobalExceptionHandler.java
+++ b/apps/dragons_api/src/main/java/com/dragons/support/error/GlobalExceptionHandler.java
@@ -5,7 +5,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.validation.BindException;
 import com.dragons.support.ApiResponse;
 
 @RestControllerAdvice
@@ -18,6 +20,23 @@ public class GlobalExceptionHandler {
     String value = e.getValue() == null ? "null" : String.valueOf(e.getValue());
     String message = String.format("요청 파라미터 '%s' 값 '%s'이(가) 올바르지 않습니다.", e.getName(), value);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.failResponse(message));
+  }
+
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+    String message = e.getBindingResult().getAllErrors().stream()
+        .findFirst()
+        .map(error -> error.getDefaultMessage() == null ? "요청 값이 올바르지 않습니다." : error.getDefaultMessage())
+        .orElse("요청 값이 올바르지 않습니다.");
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.failResponse(message));
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<ApiResponse<Void>> handleResponseStatusException(ResponseStatusException e) {
+    String message = e.getReason() == null ? "요청 값이 올바르지 않습니다." : e.getReason();
+    return ResponseEntity.status(e.getStatusCode())
         .body(ApiResponse.failResponse(message));
   }
 

--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -3,6 +3,7 @@ package com.dragons.interfaces.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import com.application.MonthlyPriceReadService;
 import com.application.PriceReadService;
 import com.support.MySqlContainerTestSupport;
 import com.repository.JpaPriceDataRepository;
@@ -12,6 +13,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.Set;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -46,6 +48,9 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   @MockitoBean
   private PriceReadService priceReadService;
 
+  @MockitoBean
+  private MonthlyPriceReadService monthlyPriceReadService;
+
   @BeforeEach
   void setUp() {
     clearBatchMetadata();
@@ -59,6 +64,8 @@ class ApiControllerTest extends MySqlContainerTestSupport {
         )
     );
     given(priceReadService.readItems(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any(LocalDate.class)))
+        .willReturn(List.of());
+    given(monthlyPriceReadService.readItems(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any(YearMonth.class)))
         .willReturn(List.of());
   }
 
@@ -121,6 +128,37 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   }
 
   @Test
+  void runMonthlyBatchReturnsBatchExecutionResult() throws Exception {
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+    given(monthlyPriceReadService.readItems("200", yearMonth))
+        .willReturn(
+            List.of(
+                new PriceReadItem("911", "테스트 배추", "01", "일반", "100", "서울", "01", "상품", 12345, "10kg", LocalDate.of(2024, 1, 15)),
+                new PriceReadItem("912", "테스트 무", "01", "일반", "100", "서울", "01", "상품", 23456, "20kg", LocalDate.of(2024, 1, 16))
+            )
+        );
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl() + "/api/batch/run-monthly?itemCategoryCode=200&yyyy=2024&mm=01"))
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
+
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).contains("\"success\":true");
+    assertThat(response.body()).contains("\"jobExecutionId\":");
+    assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
+    assertThat(response.body()).contains("\"yyyy\":\"2024\"");
+    assertThat(response.body()).contains("\"mm\":\"01\"");
+    assertThat(jdbcTemplate.queryForObject("select count(*) from BATCH_JOB_EXECUTION", Integer.class))
+        .isEqualTo(1);
+    assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("테스트"))
+        .extracting(PriceData::getItemCode)
+        .containsExactlyInAnyOrderElementsOf(Set.of("911", "912"));
+  }
+
+  @Test
   void runBatchPersistsExecutionMetadataInDatabase() throws Exception {
     LocalDate regDay = LocalDate.of(2024, 1, 15);
     given(priceReadService.readItems("200", regDay))
@@ -150,6 +188,7 @@ class ApiControllerTest extends MySqlContainerTestSupport {
     assertThat(response.statusCode()).isEqualTo(200);
     assertThat(response.body()).contains("\"count\":0");
     assertThat(response.body()).contains("\"mockMode\":false");
+    assertThat(response.body()).contains("\"apiConfigured\":true");
     assertThat(response.body()).contains("\"data\":[]");
   }
 
@@ -170,7 +209,9 @@ class ApiControllerTest extends MySqlContainerTestSupport {
 
     assertThat(response.statusCode()).isEqualTo(200);
     assertThat(response.body()).contains("\"count\":2");
+    assertThat(response.body()).contains("\"apiConfigured\":true");
     assertThat(response.body()).contains("\"jobName\":\"kamisPriceJob\"");
+    assertThat(response.body()).contains("\"jobExecutionId\":");
     assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
     assertThat(response.body()).contains("\"exitCode\":\"COMPLETED\"");
     assertThat(response.body()).contains("\"itemCategoryCode\":\"200\"");

--- a/domain/src/main/java/model/price/MonthlyPriceReader.java
+++ b/domain/src/main/java/model/price/MonthlyPriceReader.java
@@ -1,0 +1,9 @@
+package model.price;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public interface MonthlyPriceReader {
+
+  List<PriceReadItem> readInMonth(String itemCategoryCode, YearMonth yearMonth);
+}

--- a/infra/feign/src/main/java/com/source/ApiPriceSource.java
+++ b/infra/feign/src/main/java/com/source/ApiPriceSource.java
@@ -2,24 +2,32 @@ package com.source;
 
 import com.client.MarketPriceClient;
 import com.dto.MarketPriceDailyResponse;
+import com.dto.MarketPriceMonthlyResponse;
 import com.properties.MarketPriceApiProperties;
 import constant.Constants;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import model.price.MonthlyPriceReader;
 import model.price.PriceReadItem;
 import model.price.PriceReader;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ApiPriceSource implements PriceReader {
+public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
 
   private static final String DEFAULT_PERIOD = "3";
   private static final String DEFAULT_ITEM_CODE = "111";
   private static final String DEFAULT_KIND_CODE = "05";
   private static final String DEFAULT_GRADE_RANK = "2";
   private static final String DEFAULT_COUNTY_CODE = "1101";
+  private static final DateTimeFormatter KAMIS_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
   private final MarketPriceClient marketPriceClient;
   private final MarketPriceApiProperties marketPriceApiProperties;
@@ -62,6 +70,27 @@ public class ApiPriceSource implements PriceReader {
         .toList();
   }
 
+  @Override
+  public List<PriceReadItem> readInMonth(String itemCategoryCode, YearMonth yearMonth) {
+    MarketPriceMonthlyResponse response = marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        marketPriceApiProperties.getCertKey(),
+        marketPriceApiProperties.getCertId(),
+        String.valueOf(yearMonth.getYear()),
+        "%02d".formatted(yearMonth.getMonthValue()),
+        itemCategoryCode
+    );
+
+    if (response == null || response.data() == null || response.data().item() == null) {
+      return List.of();
+    }
+
+    return response.data().item().stream()
+        .flatMap(item -> toMonthlyReadItems(item, yearMonth).stream())
+        .toList();
+  }
+
   private int parsePrice(String price) {
     if (price == null) {
       return 0;
@@ -71,5 +100,49 @@ public class ApiPriceSource implements PriceReader {
       return 0;
     }
     return Integer.parseInt(normalized);
+  }
+
+  private List<PriceReadItem> toMonthlyReadItems(
+      MarketPriceMonthlyResponse.MarketPriceMonthlyItem item,
+      YearMonth targetYearMonth
+  ) {
+    List<PriceReadItem> items = new ArrayList<>();
+    Stream.of(
+            monthlyEntry(item, item.day1(), item.dpr1(), targetYearMonth),
+            monthlyEntry(item, item.day2(), item.dpr2(), targetYearMonth)
+        )
+        .flatMap(Optional::stream)
+        .forEach(items::add);
+    return items;
+  }
+
+  private Optional<PriceReadItem> monthlyEntry(
+      MarketPriceMonthlyResponse.MarketPriceMonthlyItem item,
+      String day,
+      String price,
+      YearMonth targetYearMonth
+  ) {
+    if (day == null || day.isBlank() || price == null || price.isBlank()) {
+      return Optional.empty();
+    }
+
+    LocalDate regDay = LocalDate.parse(day, KAMIS_DATE_FORMATTER);
+    if (!YearMonth.from(regDay).equals(targetYearMonth)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(new PriceReadItem(
+        item.itemCode(),
+        item.itemName(),
+        item.kindCode(),
+        item.kindName(),
+        item.marketCode(),
+        item.marketName(),
+        item.rankCode(),
+        item.rankName(),
+        parsePrice(price),
+        item.unit(),
+        regDay
+    ));
   }
 }

--- a/infra/feign/src/main/java/com/source/ApiPriceSource.java
+++ b/infra/feign/src/main/java/com/source/ApiPriceSource.java
@@ -7,6 +7,7 @@ import com.properties.MarketPriceApiProperties;
 import constant.Constants;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -126,7 +127,12 @@ public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
       return Optional.empty();
     }
 
-    LocalDate regDay = LocalDate.parse(day, KAMIS_DATE_FORMATTER);
+    final LocalDate regDay;
+    try {
+      regDay = LocalDate.parse(day, KAMIS_DATE_FORMATTER);
+    } catch (DateTimeParseException exception) {
+      return Optional.empty();
+    }
     if (!YearMonth.from(regDay).equals(targetYearMonth)) {
       return Optional.empty();
     }

--- a/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
+++ b/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.verify;
 
 import com.client.MarketPriceClient;
 import com.dto.MarketPriceDailyResponse;
+import com.dto.MarketPriceMonthlyResponse;
 import com.properties.MarketPriceApiProperties;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import model.price.PriceReadItem;
 import org.junit.jupiter.api.Test;
@@ -86,5 +88,61 @@ class ApiPriceSourceTest {
       assertThat(item.price()).isEqualTo(12000);
       assertThat(item.regDay()).isEqualTo(regDay);
     });
+  }
+
+  @Test
+  void readInMonthUsesMonthlySalesParametersAndMapsAvailableDays() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111",
+                    "배추",
+                    "01",
+                    "일반",
+                    "100",
+                    "서울",
+                    "01",
+                    "상품",
+                    "10kg",
+                    "2024/01/15",
+                    "12,000",
+                    "2024/01/16",
+                    "11,500",
+                    "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    verify(marketPriceClient).fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    );
+    assertThat(result).hasSize(2);
+    assertThat(result).extracting(PriceReadItem::regDay)
+        .containsExactly(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 16));
   }
 }

--- a/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
+++ b/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
@@ -145,4 +145,112 @@ class ApiPriceSourceTest {
     assertThat(result).extracting(PriceReadItem::regDay)
         .containsExactly(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 16));
   }
+
+  @Test
+  void readInMonthReturnsSingleItemWhenSecondDayPairIsBlank() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111", "배추", "01", "일반", "100", "서울", "01", "상품", "10kg",
+                    "2024/01/15", "12,000", "", "", "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    assertThat(result).singleElement().satisfies(item -> assertThat(item.regDay()).isEqualTo(LocalDate.of(2024, 1, 15)));
+  }
+
+  @Test
+  void readInMonthFiltersOutDaysOutsideRequestedMonth() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111", "배추", "01", "일반", "100", "서울", "01", "상품", "10kg",
+                    "2024/01/15", "12,000", "2024/02/01", "11,500", "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    assertThat(result).singleElement().satisfies(item -> assertThat(item.regDay()).isEqualTo(LocalDate.of(2024, 1, 15)));
+  }
+
+  @Test
+  void readInMonthReturnsEmptyWhenMonthlyDataIsNull() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(null));
+
+    assertThat(apiPriceSource.readInMonth("200", YearMonth.of(2024, 1))).isEmpty();
+  }
+
+  @Test
+  void readInMonthReturnsEmptyWhenMonthlyItemsAreNull() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(new MarketPriceMonthlyResponse.MarketPriceMonthlyData(null)));
+
+    assertThat(apiPriceSource.readInMonth("200", YearMonth.of(2024, 1))).isEmpty();
+  }
 }


### PR DESCRIPTION
## 요약
- step2 기준으로 월별 가격 조회 백엔드 실행 경로를 추가했습니다.
- `monthlySalesList` 응답을 기존 price 파이프라인에 연결해 월별 배치 Job과 `/api/batch/run-monthly` 엔드포인트를 구현했습니다.
- 배치 상태 응답도 실행 이력 식별과 설정값 일관성이 맞도록 함께 정리했습니다.

## 변경 사항
- `MonthlyPriceReader`, `MonthlyPriceReadService`, `KamisMonthlyItemReader`, `BatchMonthlyRunService`를 추가했습니다.
- `BatchCoreConfiguration`에 `kamisMonthlyPriceStep`, `kamisMonthlyPriceJob`을 추가했습니다.
- `BatchApiController`에 `POST /api/batch/run-monthly`를 추가하고 월별 요청/응답 DTO를 만들었습니다.
- `ApiPriceSource`에 월별 KAMIS 응답을 `PriceReadItem`으로 평탄화하는 로직을 추가했습니다.
- `/api/batch/status` 응답에 실제 `mockMode`, `apiConfigured`, `jobExecutionId`가 반영되도록 정리했습니다.
- 월별 배치/월별 reader/API 통합 테스트를 추가했습니다.

## 검증
- `./gradlew :apps:batch-core:test`
- `./gradlew :apps:dragons_api:test`

## 비고
- 프론트 `index.html`의 월별 조회 섹션은 이번 PR 범위에 포함하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 월별 배치 실행 기능 추가 및 `/api/batch/run-monthly` 엔드포인트 제공
  * 월별 실행 결과 반환 구조 추가(실행 ID, 상태, 시작/종료 시간, 년/월, mock 모드)

* **Refactor**
  * 배치 구성에 월별 처리 흐름과 reader/step/job 추가로 배치 기능 확장

* **Bug Fixes / Improvements**
  * 요청 유효성 검사 강화 및 관련 에러를 명확한 400 응답으로 처리

* **Tests**
  * 월별 실행과 reader 매핑 동작을 검증하는 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->