### PR TITLE
Step2: add monthly batch flow and React index experience

### DIFF
--- a/.omx/report/front-react-ts-scaffold-2026-04-27.md
+++ b/.omx/report/front-react-ts-scaffold-2026-04-27.md
@@ -1,0 +1,39 @@
+# Front React+TypeScript scaffold report
+
+- Date: 2026-04-27
+- Branch: `feat/14-월별-가격-조회-배치와-run-monthly-엔드포인트를-추가한다`
+
+## Summary
+
+Created a new root `front/` application scaffold using React + TypeScript with a Vite-style entry structure.
+
+## Added
+
+- `front/index.html`
+- `front/package.json`
+- `front/vite.config.ts`
+- `front/tsconfig.json`
+- `front/tsconfig.app.json`
+- `front/tsconfig.node.json`
+- `front/src/main.tsx`
+- `front/src/App.tsx`
+- `front/src/styles.css`
+- `front/src/vite-env.d.ts`
+- `front/.gitignore`
+
+## Purpose
+
+- Establish a dedicated frontend workspace under the repo root.
+- Use TypeScript + React as the baseline stack for the main screen work.
+- Keep `index.html` at the app root so it can serve as the frontend entrypoint.
+
+## Verification
+
+- Confirmed scaffold files exist under `front/`.
+- Did not run `npm install`, `vite`, or production build yet.
+
+## Remaining follow-ups
+
+- Install frontend dependencies.
+- Implement the main-screen monthly batch UI.
+- Align frontend request/response naming with backend/API docs.

--- a/apps/batch-core/src/main/java/com/application/BatchManualRunService.java
+++ b/apps/batch-core/src/main/java/com/application/BatchManualRunService.java
@@ -6,24 +6,35 @@ import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class BatchManualRunService {
 
   private final JobOperator jobOperator;
   private final Job kamisPriceJob;
   private final JdbcTemplate jdbcTemplate;
   private final Clock clock;
+
+  public BatchManualRunService(
+      JobOperator jobOperator,
+      @Qualifier("kamisPriceJob") Job kamisPriceJob,
+      JdbcTemplate jdbcTemplate,
+      Clock clock
+  ) {
+    this.jobOperator = jobOperator;
+    this.kamisPriceJob = kamisPriceJob;
+    this.jdbcTemplate = jdbcTemplate;
+    this.clock = clock;
+  }
 
   public BatchRunResult run(String itemCategoryCode, LocalDate regDay) {
     try {

--- a/apps/batch-core/src/main/java/com/application/BatchMonthlyRunService.java
+++ b/apps/batch-core/src/main/java/com/application/BatchMonthlyRunService.java
@@ -1,0 +1,66 @@
+package com.application;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BatchMonthlyRunService {
+
+  private final JobOperator jobOperator;
+  private final Job kamisMonthlyPriceJob;
+  private final Clock clock;
+
+  public BatchMonthlyRunService(
+      JobOperator jobOperator,
+      @Qualifier("kamisMonthlyPriceJob") Job kamisMonthlyPriceJob,
+      Clock clock
+  ) {
+    this.jobOperator = jobOperator;
+    this.kamisMonthlyPriceJob = kamisMonthlyPriceJob;
+    this.clock = clock;
+  }
+
+  public BatchRunResult run(String itemCategoryCode, YearMonth yearMonth) {
+    try {
+      JobExecution jobExecution = jobOperator.start(
+          kamisMonthlyPriceJob,
+          new JobParametersBuilder()
+              .addString("itemCategoryCode", itemCategoryCode)
+              .addString("yyyy", String.valueOf(yearMonth.getYear()))
+              .addString("mm", "%02d".formatted(yearMonth.getMonthValue()))
+              .addLong("requestedAt", clock.millis())
+              .toJobParameters()
+      );
+
+      if (jobExecution.getStatus() != BatchStatus.COMPLETED) {
+        throw new IllegalStateException(
+            "월별 배치 실행에 실패했습니다.",
+            jobExecution.getAllFailureExceptions().stream().findFirst().orElse(null)
+        );
+      }
+
+      return new BatchRunResult(
+          jobExecution.getId(),
+          jobExecution.getStatus().name(),
+          jobExecution.getStartTime(),
+          jobExecution.getEndTime(),
+          jobExecution.getStepExecutions().stream()
+              .mapToLong(StepExecution::getWriteCount)
+              .sum()
+      );
+    } catch (IllegalStateException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      throw new IllegalStateException("월별 배치 실행에 실패했습니다.", exception);
+    }
+  }
+}

--- a/apps/batch-core/src/main/java/com/application/MonthlyPriceReadService.java
+++ b/apps/batch-core/src/main/java/com/application/MonthlyPriceReadService.java
@@ -1,0 +1,19 @@
+package com.application;
+
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import model.price.MonthlyPriceReader;
+import model.price.PriceReadItem;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyPriceReadService {
+
+  private final MonthlyPriceReader monthlyPriceReader;
+
+  public List<PriceReadItem> readItems(String itemCategoryCode, YearMonth yearMonth) {
+    return monthlyPriceReader.readInMonth(itemCategoryCode, yearMonth);
+  }
+}

--- a/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
+++ b/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
@@ -1,11 +1,14 @@
 package com.config;
 
+import com.application.MonthlyPriceReadService;
 import com.application.PriceReadService;
 import com.process.KamisItemProcessor;
 import com.read.KamisItemReader;
+import com.read.KamisMonthlyItemReader;
 import com.write.KamisItemWriter;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import model.price.PriceData;
 import model.price.PriceDataRepository;
 import model.price.PriceReadItem;
@@ -19,6 +22,7 @@ import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.ItemReader;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -48,6 +52,25 @@ public class BatchCoreConfiguration {
   }
 
   @Bean
+  @StepScope
+  ItemReader<PriceReadItem> kamisMonthlyItemReader(
+      MonthlyPriceReadService monthlyPriceReadService,
+      @Value("#{jobParameters['itemCategoryCode']}") String itemCategoryCode,
+      @Value("#{jobParameters['yyyy']}") String yyyy,
+      @Value("#{jobParameters['mm']}") String mm
+  ) {
+    YearMonth yearMonth = (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank())
+        ? YearMonth.now()
+        : YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+
+    return new KamisMonthlyItemReader(
+        monthlyPriceReadService,
+        itemCategoryCode == null || itemCategoryCode.isBlank() ? "200" : itemCategoryCode,
+        yearMonth
+    );
+  }
+
+  @Bean
   ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor(Clock batchClock) {
     return new KamisItemProcessor(batchClock);
   }
@@ -61,7 +84,7 @@ public class BatchCoreConfiguration {
   Step kamisPriceStep(
       JobRepository jobRepository,
       PlatformTransactionManager transactionManager,
-      ItemReader<PriceReadItem> kamisItemReader,
+      @Qualifier("kamisItemReader") ItemReader<PriceReadItem> kamisItemReader,
       ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor,
       ItemWriter<PriceData> kamisItemWriter
   ) {
@@ -75,9 +98,36 @@ public class BatchCoreConfiguration {
   }
 
   @Bean
-  Job kamisPriceJob(JobRepository jobRepository, Step kamisPriceStep) {
+  Job kamisPriceJob(JobRepository jobRepository, @Qualifier("kamisPriceStep") Step kamisPriceStep) {
     return new JobBuilder("kamisPriceJob", jobRepository)
         .start(kamisPriceStep)
+        .build();
+  }
+
+  @Bean
+  Step kamisMonthlyPriceStep(
+      JobRepository jobRepository,
+      PlatformTransactionManager transactionManager,
+      @Qualifier("kamisMonthlyItemReader") ItemReader<PriceReadItem> kamisMonthlyItemReader,
+      ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor,
+      ItemWriter<PriceData> kamisItemWriter
+  ) {
+    return new StepBuilder("kamisMonthlyPriceStep", jobRepository)
+        .<PriceReadItem, PriceData>chunk(CHUNK_SIZE)
+        .transactionManager(transactionManager)
+        .reader(kamisMonthlyItemReader)
+        .processor(kamisItemProcessor)
+        .writer(kamisItemWriter)
+        .build();
+  }
+
+  @Bean
+  Job kamisMonthlyPriceJob(
+      JobRepository jobRepository,
+      @Qualifier("kamisMonthlyPriceStep") Step kamisMonthlyPriceStep
+  ) {
+    return new JobBuilder("kamisMonthlyPriceJob", jobRepository)
+        .start(kamisMonthlyPriceStep)
         .build();
   }
 }

--- a/apps/batch-core/src/main/java/com/read/KamisMonthlyItemReader.java
+++ b/apps/batch-core/src/main/java/com/read/KamisMonthlyItemReader.java
@@ -1,0 +1,33 @@
+package com.read;
+
+import com.application.MonthlyPriceReadService;
+import java.time.YearMonth;
+import java.util.Iterator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import model.price.PriceReadItem;
+import org.springframework.batch.infrastructure.item.ItemReader;
+
+@RequiredArgsConstructor
+public class KamisMonthlyItemReader implements ItemReader<PriceReadItem> {
+
+  private final MonthlyPriceReadService monthlyPriceReadService;
+  private final String itemCategoryCode;
+  private final YearMonth yearMonth;
+
+  private Iterator<PriceReadItem> iterator;
+
+  @Override
+  public PriceReadItem read() {
+    if (iterator == null) {
+      List<PriceReadItem> items = monthlyPriceReadService.readItems(itemCategoryCode, yearMonth);
+      iterator = items.iterator();
+    }
+
+    if (!iterator.hasNext()) {
+      return null;
+    }
+
+    return iterator.next();
+  }
+}

--- a/apps/batch-core/src/main/java/com/read/KamisMonthlyItemReader.java
+++ b/apps/batch-core/src/main/java/com/read/KamisMonthlyItemReader.java
@@ -2,6 +2,7 @@ package com.read;
 
 import com.application.MonthlyPriceReadService;
 import java.time.YearMonth;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,9 @@ public class KamisMonthlyItemReader implements ItemReader<PriceReadItem> {
   public PriceReadItem read() {
     if (iterator == null) {
       List<PriceReadItem> items = monthlyPriceReadService.readItems(itemCategoryCode, yearMonth);
+      if (items == null) {
+        items = Collections.emptyList();
+      }
       iterator = items.iterator();
     }
 

--- a/apps/batch-core/src/test/java/com/application/BatchMonthlyRunServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/BatchMonthlyRunServiceTest.java
@@ -1,0 +1,82 @@
+package com.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.batch.core.step.StepExecution;
+
+class BatchMonthlyRunServiceTest {
+
+  @Test
+  void runLaunchesMonthlyJobWithRequestParametersAndReturnsExecutionSummary() throws Exception {
+    JobOperator jobOperator = mock(JobOperator.class);
+    Job kamisMonthlyPriceJob = mock(Job.class);
+    Clock clock = Clock.fixed(Instant.parse("2026-04-21T00:00:00Z"), ZoneOffset.UTC);
+    JobExecution jobExecution = mock(JobExecution.class);
+    StepExecution stepExecution = mock(StepExecution.class);
+    BatchMonthlyRunService batchMonthlyRunService = new BatchMonthlyRunService(jobOperator, kamisMonthlyPriceJob, clock);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(jobOperator.start(eq(kamisMonthlyPriceJob), org.mockito.ArgumentMatchers.any(JobParameters.class)))
+        .willReturn(jobExecution);
+    given(jobExecution.getStatus()).willReturn(BatchStatus.COMPLETED);
+    given(jobExecution.getId()).willReturn(41L);
+    given(jobExecution.getStartTime()).willReturn(LocalDateTime.of(2024, 1, 31, 10, 0));
+    given(jobExecution.getEndTime()).willReturn(LocalDateTime.of(2024, 1, 31, 10, 1));
+    given(jobExecution.getStepExecutions()).willReturn(Set.of(stepExecution));
+    given(stepExecution.getWriteCount()).willReturn(4L);
+
+    BatchRunResult result = batchMonthlyRunService.run("200", yearMonth);
+
+    ArgumentCaptor<JobParameters> jobParametersCaptor = ArgumentCaptor.forClass(JobParameters.class);
+    then(jobOperator).should().start(eq(kamisMonthlyPriceJob), jobParametersCaptor.capture());
+
+    JobParameters jobParameters = jobParametersCaptor.getValue();
+    assertThat(jobParameters.getString("itemCategoryCode")).isEqualTo("200");
+    assertThat(jobParameters.getString("yyyy")).isEqualTo("2024");
+    assertThat(jobParameters.getString("mm")).isEqualTo("01");
+    assertThat(jobParameters.getLong("requestedAt")).isEqualTo(clock.millis());
+
+    assertThat(result.jobExecutionId()).isEqualTo(41L);
+    assertThat(result.status()).isEqualTo("COMPLETED");
+    assertThat(result.writeCount()).isEqualTo(4);
+  }
+
+  @Test
+  void runThrowsWhenMonthlyBatchExecutionFails() throws Exception {
+    JobOperator jobOperator = mock(JobOperator.class);
+    Job kamisMonthlyPriceJob = mock(Job.class);
+    Clock clock = Clock.fixed(Instant.parse("2026-04-21T00:00:00Z"), ZoneOffset.UTC);
+    JobExecution jobExecution = mock(JobExecution.class);
+    BatchMonthlyRunService batchMonthlyRunService = new BatchMonthlyRunService(jobOperator, kamisMonthlyPriceJob, clock);
+    RuntimeException failure = new RuntimeException("monthly writer failed");
+
+    given(jobOperator.start(eq(kamisMonthlyPriceJob), org.mockito.ArgumentMatchers.any(JobParameters.class)))
+        .willReturn(jobExecution);
+    given(jobExecution.getStatus()).willReturn(BatchStatus.FAILED);
+    given(jobExecution.getAllFailureExceptions()).willReturn(List.of(failure));
+
+    assertThatThrownBy(() -> batchMonthlyRunService.run("200", YearMonth.of(2024, 1)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("월별 배치 실행에 실패했습니다.")
+        .hasRootCause(failure);
+  }
+}

--- a/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
@@ -1,0 +1,29 @@
+package com.application.monthly;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.application.MonthlyPriceReadService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import model.price.MonthlyPriceReader;
+import model.price.PriceReadItem;
+import org.junit.jupiter.api.Test;
+
+class MonthlyPriceReadServiceTest {
+
+  @Test
+  void readItemsDelegatesToMonthlyReader() {
+    MonthlyPriceReader monthlyPriceReader = org.mockito.Mockito.mock(MonthlyPriceReader.class);
+    MonthlyPriceReadService monthlyPriceReadService = new MonthlyPriceReadService(monthlyPriceReader);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+    List<PriceReadItem> expected = List.of(
+        new PriceReadItem("111", "배추", "01", "일반", "100", "서울", "01", "상품", 12000, "10kg", LocalDate.of(2024, 1, 15))
+    );
+
+    given(monthlyPriceReader.readInMonth("200", yearMonth)).willReturn(expected);
+
+    assertThat(monthlyPriceReadService.readItems("200", yearMonth)).isEqualTo(expected);
+  }
+}

--- a/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/monthly/MonthlyPriceReadServiceTest.java
@@ -2,6 +2,7 @@ package com.application.monthly;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import com.application.MonthlyPriceReadService;
 import java.time.LocalDate;
@@ -15,7 +16,7 @@ class MonthlyPriceReadServiceTest {
 
   @Test
   void readItemsDelegatesToMonthlyReader() {
-    MonthlyPriceReader monthlyPriceReader = org.mockito.Mockito.mock(MonthlyPriceReader.class);
+    MonthlyPriceReader monthlyPriceReader = mock(MonthlyPriceReader.class);
     MonthlyPriceReadService monthlyPriceReadService = new MonthlyPriceReadService(monthlyPriceReader);
     YearMonth yearMonth = YearMonth.of(2024, 1);
     List<PriceReadItem> expected = List.of(

--- a/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
+++ b/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
@@ -1,0 +1,34 @@
+package com.read;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.application.MonthlyPriceReadService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import model.price.PriceReadItem;
+import org.junit.jupiter.api.Test;
+
+class KamisMonthlyItemReaderTest {
+
+  @Test
+  void readReturnsMonthlyItemsInOrderAndThenNull() {
+    MonthlyPriceReadService monthlyPriceReadService = org.mockito.Mockito.mock(MonthlyPriceReadService.class);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(monthlyPriceReadService.readItems("200", yearMonth))
+        .willReturn(
+            List.of(
+                new PriceReadItem("111", "배추", "01", "일반", "100", "서울", "01", "상품", 12000, "10kg", LocalDate.of(2024, 1, 15)),
+                new PriceReadItem("112", "무", "01", "일반", "100", "서울", "01", "상품", 9800, "20kg", LocalDate.of(2024, 1, 16))
+            )
+        );
+
+    KamisMonthlyItemReader reader = new KamisMonthlyItemReader(monthlyPriceReadService, "200", yearMonth);
+
+    assertThat(reader.read().itemCode()).isEqualTo("111");
+    assertThat(reader.read().itemCode()).isEqualTo("112");
+    assertThat(reader.read()).isNull();
+  }
+}

--- a/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
+++ b/apps/batch-core/src/test/java/com/read/KamisMonthlyItemReaderTest.java
@@ -2,6 +2,9 @@ package com.read;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.application.MonthlyPriceReadService;
 import java.time.LocalDate;
@@ -14,7 +17,7 @@ class KamisMonthlyItemReaderTest {
 
   @Test
   void readReturnsMonthlyItemsInOrderAndThenNull() {
-    MonthlyPriceReadService monthlyPriceReadService = org.mockito.Mockito.mock(MonthlyPriceReadService.class);
+    MonthlyPriceReadService monthlyPriceReadService = mock(MonthlyPriceReadService.class);
     YearMonth yearMonth = YearMonth.of(2024, 1);
 
     given(monthlyPriceReadService.readItems("200", yearMonth))
@@ -30,5 +33,19 @@ class KamisMonthlyItemReaderTest {
     assertThat(reader.read().itemCode()).isEqualTo("111");
     assertThat(reader.read().itemCode()).isEqualTo("112");
     assertThat(reader.read()).isNull();
+    verify(monthlyPriceReadService, times(1)).readItems("200", yearMonth);
+  }
+
+  @Test
+  void readReturnsNullImmediatelyWhenMonthlyItemsAreEmpty() {
+    MonthlyPriceReadService monthlyPriceReadService = mock(MonthlyPriceReadService.class);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(monthlyPriceReadService.readItems("200", yearMonth)).willReturn(List.of());
+
+    KamisMonthlyItemReader reader = new KamisMonthlyItemReader(monthlyPriceReadService, "200", yearMonth);
+
+    assertThat(reader.read()).isNull();
+    verify(monthlyPriceReadService, times(1)).readItems("200", yearMonth);
   }
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -142,21 +142,21 @@ public class BatchApiController {
         : request.regDay();
   }
 
-  private YearMonth resolveYearMonth(String yyyy, String mm) {
-    boolean yyyyProvided = yyyy != null && !yyyy.isBlank();
-    boolean mmProvided = mm != null && !mm.isBlank();
+  private YearMonth resolveYearMonth(String year, String month) {
+    boolean yearProvided = year != null && !year.isBlank();
+    boolean monthProvided = month != null && !month.isBlank();
 
-    if (!yyyyProvided && !mmProvided) {
+    if (!yearProvided && !monthProvided) {
       return YearMonth.now();
     }
-    if (yyyyProvided != mmProvided) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "yyyy와 mm은 함께 입력해야 합니다.");
+    if (yearProvided != monthProvided) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "year와 month는 함께 입력해야 합니다.");
     }
 
     try {
-      return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+      return YearMonth.of(Integer.parseInt(year), Integer.parseInt(month));
     } catch (NumberFormatException | DateTimeException exception) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "yyyy/mm 형식이 올바르지 않습니다.", exception);
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "year/month 형식이 올바르지 않습니다.", exception);
     }
   }
 

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -64,7 +64,7 @@ public class BatchApiController {
   @Operation(summary = "월별 배치 수동 실행")
   public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@Valid @ModelAttribute BatchMonthlyRunRequest request) {
     String itemCategoryCode = resolveItemCategoryCode(request.itemCategoryCode());
-    YearMonth targetYearMonth = resolveYearMonth(request.yyyy(), request.mm());
+    YearMonth targetYearMonth = resolveYearMonth(request.year(), request.month());
     BatchRunResult result = batchMonthlyRunService.run(itemCategoryCode, targetYearMonth);
 
     return ApiResponse.successResponse(

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -133,7 +133,12 @@ public class BatchApiController {
   }
 
   private String resolveItemCategoryCode(String itemCategoryCode) {
-    return itemCategoryCode == null || itemCategoryCode.isBlank() ? "200" : itemCategoryCode;
+    if (itemCategoryCode == null) {
+      return "200";
+    }
+
+    String normalized = itemCategoryCode.trim();
+    return normalized.isEmpty() ? "200" : normalized;
   }
 
   private String resolveRegDay(BatchRunRequest request) {

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -1,9 +1,12 @@
 package com.dragons.interfaces.api.batch;
 
+import com.application.BatchMonthlyRunService;
 import com.application.BatchManualRunService;
 import com.application.BatchRunResult;
 import com.application.BatchStatusResult;
 import com.dragons.interfaces.api.batch.dto.BatchConfigResponse;
+import com.dragons.interfaces.api.batch.dto.BatchMonthlyRunRequest;
+import com.dragons.interfaces.api.batch.dto.BatchMonthlyRunResponse;
 import com.dragons.interfaces.api.batch.dto.BatchRunRequest;
 import com.dragons.interfaces.api.batch.dto.BatchRunResponse;
 import com.dragons.interfaces.api.batch.dto.BatchStatusItemResponse;
@@ -15,6 +18,7 @@ import constant.Constants;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BatchApiController {
 
+  private final BatchMonthlyRunService batchMonthlyRunService;
   private final BatchManualRunService batchManualRunService;
   private final MarketPriceApiProperties marketPriceApiProperties;
 
@@ -52,18 +57,44 @@ public class BatchApiController {
     ));
   }
 
+  @PostMapping("/run-monthly")
+  @Operation(summary = "월별 배치 수동 실행")
+  public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@ModelAttribute BatchMonthlyRunRequest request) {
+    String itemCategoryCode = resolveItemCategoryCode(request.itemCategoryCode());
+    YearMonth targetYearMonth = resolveYearMonth(request.yyyy(), request.mm());
+    BatchRunResult result = batchMonthlyRunService.run(itemCategoryCode, targetYearMonth);
+
+    return ApiResponse.successResponse(
+        new BatchMonthlyRunResponse(
+            result.jobExecutionId(),
+            result.status(),
+            formatDateTime(result.startTime()),
+            formatDateTime(result.endTime()),
+            itemCategoryCode,
+            String.valueOf(targetYearMonth.getYear()),
+            "%02d".formatted(targetYearMonth.getMonthValue()),
+            marketPriceApiProperties.isMockMode()
+        )
+    );
+  }
+
   @GetMapping("/status")
   @Operation(summary = "배치 실행 이력 조회")
   public ApiResponse<BatchStatusResponse> getBatchStatus(@ModelAttribute BatchStatusRequest request) {
     BatchStatusResult result = batchManualRunService.latestStatuses(request.resolvedLimit());
+    boolean certKeySet = hasConcreteValue(marketPriceApiProperties.getCertKey());
+    boolean certIdSet = hasConcreteValue(marketPriceApiProperties.getCertId());
+    boolean mockMode = marketPriceApiProperties.isMockMode();
+
     return ApiResponse.successResponse(
         new BatchStatusResponse(
             result.count(),
-            false,
-            false,
+            mockMode,
+            certKeySet && certIdSet && !mockMode,
             result.items().stream()
                 .map(item -> new BatchStatusItemResponse(
                     item.jobInstanceId(),
+                    item.jobExecutionId(),
                     item.jobName(),
                     item.status(),
                     formatDateTime(item.startTime()),
@@ -95,15 +126,24 @@ public class BatchApiController {
   }
 
   private String resolveItemCategoryCode(BatchRunRequest request) {
-    return request.itemCategoryCode() == null || request.itemCategoryCode().isBlank()
-        ? "200"
-        : request.itemCategoryCode();
+    return resolveItemCategoryCode(request.itemCategoryCode());
+  }
+
+  private String resolveItemCategoryCode(String itemCategoryCode) {
+    return itemCategoryCode == null || itemCategoryCode.isBlank() ? "200" : itemCategoryCode;
   }
 
   private String resolveRegDay(BatchRunRequest request) {
     return request.regDay() == null || request.regDay().isBlank()
         ? LocalDate.now().toString()
         : request.regDay();
+  }
+
+  private YearMonth resolveYearMonth(String yyyy, String mm) {
+    if (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank()) {
+      return YearMonth.now();
+    }
+    return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
   }
 
   private String formatDateTime(java.time.LocalDateTime value) {

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -1,7 +1,7 @@
 package com.dragons.interfaces.api.batch;
 
-import com.application.BatchMonthlyRunService;
 import com.application.BatchManualRunService;
+import com.application.BatchMonthlyRunService;
 import com.application.BatchRunResult;
 import com.application.BatchStatusResult;
 import com.dragons.interfaces.api.batch.dto.BatchConfigResponse;
@@ -17,15 +17,18 @@ import com.properties.MarketPriceApiProperties;
 import constant.Constants;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/batch")
@@ -59,7 +62,7 @@ public class BatchApiController {
 
   @PostMapping("/run-monthly")
   @Operation(summary = "월별 배치 수동 실행")
-  public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@ModelAttribute BatchMonthlyRunRequest request) {
+  public ApiResponse<BatchMonthlyRunResponse> runMonthlyBatch(@Valid @ModelAttribute BatchMonthlyRunRequest request) {
     String itemCategoryCode = resolveItemCategoryCode(request.itemCategoryCode());
     YearMonth targetYearMonth = resolveYearMonth(request.yyyy(), request.mm());
     BatchRunResult result = batchMonthlyRunService.run(itemCategoryCode, targetYearMonth);
@@ -140,10 +143,21 @@ public class BatchApiController {
   }
 
   private YearMonth resolveYearMonth(String yyyy, String mm) {
-    if (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank()) {
+    boolean yyyyProvided = yyyy != null && !yyyy.isBlank();
+    boolean mmProvided = mm != null && !mm.isBlank();
+
+    if (!yyyyProvided && !mmProvided) {
       return YearMonth.now();
     }
-    return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+    if (yyyyProvided != mmProvided) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "yyyy와 mm은 함께 입력해야 합니다.");
+    }
+
+    try {
+      return YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+    } catch (NumberFormatException | DateTimeException exception) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "yyyy/mm 형식이 올바르지 않습니다.", exception);
+    }
   }
 
   private String formatDateTime(java.time.LocalDateTime value) {

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/BatchApiController.java
@@ -146,10 +146,7 @@ public class BatchApiController {
     boolean yearProvided = year != null && !year.isBlank();
     boolean monthProvided = month != null && !month.isBlank();
 
-    if (!yearProvided && !monthProvided) {
-      return YearMonth.now();
-    }
-    if (yearProvided != monthProvided) {
+    if (!yearProvided || !monthProvided) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "year와 month는 함께 입력해야 합니다.");
     }
 

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -1,0 +1,8 @@
+package com.dragons.interfaces.api.batch.dto;
+
+public record BatchMonthlyRunRequest(
+    String itemCategoryCode,
+    String yyyy,
+    String mm
+) {
+}

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -7,9 +7,9 @@ public record BatchMonthlyRunRequest(
     @NotBlank(message = "itemCategoryCode는 필수입니다.") String itemCategoryCode,
     @NotBlank(message = "yyyy는 필수입니다.")
     @Pattern(regexp = "\\d{4}", message = "yyyy는 4자리 연도여야 합니다.")
-    String yyyy,
+    String year,
     @NotBlank(message = "mm는 필수입니다.")
     @Pattern(regexp = "(0[1-9]|1[0-2])", message = "mm는 01~12 형식이어야 합니다.")
-    String mm
+    String month
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -1,8 +1,15 @@
 package com.dragons.interfaces.api.batch.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record BatchMonthlyRunRequest(
-    String itemCategoryCode,
+    @NotBlank(message = "itemCategoryCode는 필수입니다.") String itemCategoryCode,
+    @NotBlank(message = "yyyy는 필수입니다.")
+    @Pattern(regexp = "\\d{4}", message = "yyyy는 4자리 연도여야 합니다.")
     String yyyy,
+    @NotBlank(message = "mm는 필수입니다.")
+    @Pattern(regexp = "(0[1-9]|1[0-2])", message = "mm는 01~12 형식이어야 합니다.")
     String mm
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunRequest.java
@@ -5,11 +5,11 @@ import jakarta.validation.constraints.Pattern;
 
 public record BatchMonthlyRunRequest(
     @NotBlank(message = "itemCategoryCode는 필수입니다.") String itemCategoryCode,
-    @NotBlank(message = "yyyy는 필수입니다.")
-    @Pattern(regexp = "\\d{4}", message = "yyyy는 4자리 연도여야 합니다.")
+    @NotBlank(message = "year는 필수입니다.")
+    @Pattern(regexp = "\\d{4}", message = "year는 4자리 연도여야 합니다.")
     String year,
-    @NotBlank(message = "mm는 필수입니다.")
-    @Pattern(regexp = "(0[1-9]|1[0-2])", message = "mm는 01~12 형식이어야 합니다.")
+    @NotBlank(message = "month는 필수입니다.")
+    @Pattern(regexp = "(0[1-9]|1[0-2])", message = "month는 01~12 형식이어야 합니다.")
     String month
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
@@ -6,8 +6,8 @@ public record BatchMonthlyRunResponse(
     String startTime,
     String endTime,
     String itemCategoryCode,
-    String yyyy,
-    String mm,
+    String year,
+    String month,
     boolean mockMode
 ) {
 }

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchMonthlyRunResponse.java
@@ -1,0 +1,13 @@
+package com.dragons.interfaces.api.batch.dto;
+
+public record BatchMonthlyRunResponse(
+    long jobExecutionId,
+    String status,
+    String startTime,
+    String endTime,
+    String itemCategoryCode,
+    String yyyy,
+    String mm,
+    boolean mockMode
+) {
+}

--- a/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchStatusItemResponse.java
+++ b/apps/dragons_api/src/main/java/com/dragons/interfaces/api/batch/dto/BatchStatusItemResponse.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 public record BatchStatusItemResponse(
     long jobInstanceId,
+    long jobExecutionId,
     String jobName,
     String status,
     String startTime,

--- a/apps/dragons_api/src/main/java/com/dragons/support/error/GlobalExceptionHandler.java
+++ b/apps/dragons_api/src/main/java/com/dragons/support/error/GlobalExceptionHandler.java
@@ -5,7 +5,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.validation.BindException;
 import com.dragons.support.ApiResponse;
 
 @RestControllerAdvice
@@ -18,6 +20,23 @@ public class GlobalExceptionHandler {
     String value = e.getValue() == null ? "null" : String.valueOf(e.getValue());
     String message = String.format("요청 파라미터 '%s' 값 '%s'이(가) 올바르지 않습니다.", e.getName(), value);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.failResponse(message));
+  }
+
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+    String message = e.getBindingResult().getAllErrors().stream()
+        .findFirst()
+        .map(error -> error.getDefaultMessage() == null ? "요청 값이 올바르지 않습니다." : error.getDefaultMessage())
+        .orElse("요청 값이 올바르지 않습니다.");
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.failResponse(message));
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<ApiResponse<Void>> handleResponseStatusException(ResponseStatusException e) {
+    String message = e.getReason() == null ? "요청 값이 올바르지 않습니다." : e.getReason();
+    return ResponseEntity.status(e.getStatusCode())
         .body(ApiResponse.failResponse(message));
   }
 

--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -159,6 +159,32 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   }
 
   @Test
+  void runMonthlyBatchReturnsBadRequestForInvalidYearMonth() throws Exception {
+    HttpRequest invalidYearRequest = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl() + "/api/batch/run-monthly?itemCategoryCode=200&year=20&month=01"))
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
+    HttpRequest invalidMonthRequest = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl() + "/api/batch/run-monthly?itemCategoryCode=200&year=2024&month=13"))
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
+
+    HttpResponse<String> invalidYearResponse = httpClient.send(invalidYearRequest, HttpResponse.BodyHandlers.ofString());
+    HttpResponse<String> invalidMonthResponse = httpClient.send(invalidMonthRequest, HttpResponse.BodyHandlers.ofString());
+
+    assertThat(invalidYearResponse.statusCode()).isEqualTo(400);
+    assertThat(invalidYearResponse.body()).contains("\"success\":false");
+    assertThat(invalidYearResponse.body()).contains("year는 4자리 연도여야 합니다.");
+    assertThat(invalidMonthResponse.statusCode()).isEqualTo(400);
+    assertThat(invalidMonthResponse.body()).contains("\"success\":false");
+    assertThat(invalidMonthResponse.body()).contains("month는 01~12 형식이어야 합니다.");
+    assertThat(jdbcTemplate.queryForObject("select count(*) from BATCH_JOB_EXECUTION", Integer.class))
+        .isEqualTo(0);
+    assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("테스트"))
+        .isEmpty();
+  }
+
+  @Test
   void runBatchPersistsExecutionMetadataInDatabase() throws Exception {
     LocalDate regDay = LocalDate.of(2024, 1, 15);
     given(priceReadService.readItems("200", regDay))

--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -139,7 +139,7 @@ class ApiControllerTest extends MySqlContainerTestSupport {
         );
 
     HttpRequest request = HttpRequest.newBuilder()
-        .uri(URI.create(baseUrl() + "/api/batch/run-monthly?itemCategoryCode=200&yyyy=2024&mm=01"))
+        .uri(URI.create(baseUrl() + "/api/batch/run-monthly?itemCategoryCode=200&year=2024&month=01"))
         .POST(HttpRequest.BodyPublishers.noBody())
         .build();
 
@@ -149,8 +149,8 @@ class ApiControllerTest extends MySqlContainerTestSupport {
     assertThat(response.body()).contains("\"success\":true");
     assertThat(response.body()).contains("\"jobExecutionId\":");
     assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
-    assertThat(response.body()).contains("\"yyyy\":\"2024\"");
-    assertThat(response.body()).contains("\"mm\":\"01\"");
+    assertThat(response.body()).contains("\"year\":\"2024\"");
+    assertThat(response.body()).contains("\"month\":\"01\"");
     assertThat(jdbcTemplate.queryForObject("select count(*) from BATCH_JOB_EXECUTION", Integer.class))
         .isEqualTo(1);
     assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("테스트"))

--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -3,6 +3,7 @@ package com.dragons.interfaces.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import com.application.MonthlyPriceReadService;
 import com.application.PriceReadService;
 import com.support.MySqlContainerTestSupport;
 import com.repository.JpaPriceDataRepository;
@@ -12,6 +13,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.Set;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -46,6 +48,9 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   @MockitoBean
   private PriceReadService priceReadService;
 
+  @MockitoBean
+  private MonthlyPriceReadService monthlyPriceReadService;
+
   @BeforeEach
   void setUp() {
     clearBatchMetadata();
@@ -59,6 +64,8 @@ class ApiControllerTest extends MySqlContainerTestSupport {
         )
     );
     given(priceReadService.readItems(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any(LocalDate.class)))
+        .willReturn(List.of());
+    given(monthlyPriceReadService.readItems(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any(YearMonth.class)))
         .willReturn(List.of());
   }
 
@@ -121,6 +128,37 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   }
 
   @Test
+  void runMonthlyBatchReturnsBatchExecutionResult() throws Exception {
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+    given(monthlyPriceReadService.readItems("200", yearMonth))
+        .willReturn(
+            List.of(
+                new PriceReadItem("911", "테스트 배추", "01", "일반", "100", "서울", "01", "상품", 12345, "10kg", LocalDate.of(2024, 1, 15)),
+                new PriceReadItem("912", "테스트 무", "01", "일반", "100", "서울", "01", "상품", 23456, "20kg", LocalDate.of(2024, 1, 16))
+            )
+        );
+
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl() + "/api/batch/run-monthly?itemCategoryCode=200&yyyy=2024&mm=01"))
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
+
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).contains("\"success\":true");
+    assertThat(response.body()).contains("\"jobExecutionId\":");
+    assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
+    assertThat(response.body()).contains("\"yyyy\":\"2024\"");
+    assertThat(response.body()).contains("\"mm\":\"01\"");
+    assertThat(jdbcTemplate.queryForObject("select count(*) from BATCH_JOB_EXECUTION", Integer.class))
+        .isEqualTo(1);
+    assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("테스트"))
+        .extracting(PriceData::getItemCode)
+        .containsExactlyInAnyOrderElementsOf(Set.of("911", "912"));
+  }
+
+  @Test
   void runBatchPersistsExecutionMetadataInDatabase() throws Exception {
     LocalDate regDay = LocalDate.of(2024, 1, 15);
     given(priceReadService.readItems("200", regDay))
@@ -150,6 +188,7 @@ class ApiControllerTest extends MySqlContainerTestSupport {
     assertThat(response.statusCode()).isEqualTo(200);
     assertThat(response.body()).contains("\"count\":0");
     assertThat(response.body()).contains("\"mockMode\":false");
+    assertThat(response.body()).contains("\"apiConfigured\":true");
     assertThat(response.body()).contains("\"data\":[]");
   }
 
@@ -170,7 +209,9 @@ class ApiControllerTest extends MySqlContainerTestSupport {
 
     assertThat(response.statusCode()).isEqualTo(200);
     assertThat(response.body()).contains("\"count\":2");
+    assertThat(response.body()).contains("\"apiConfigured\":true");
     assertThat(response.body()).contains("\"jobName\":\"kamisPriceJob\"");
+    assertThat(response.body()).contains("\"jobExecutionId\":");
     assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
     assertThat(response.body()).contains("\"exitCode\":\"COMPLETED\"");
     assertThat(response.body()).contains("\"itemCategoryCode\":\"200\"");

--- a/domain/src/main/java/model/price/MonthlyPriceReader.java
+++ b/domain/src/main/java/model/price/MonthlyPriceReader.java
@@ -1,0 +1,9 @@
+package model.price;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public interface MonthlyPriceReader {
+
+  List<PriceReadItem> readInMonth(String itemCategoryCode, YearMonth yearMonth);
+}

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.local

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 dist
 *.local
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts

--- a/front/index.html
+++ b/front/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dragons Batch Front</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,0 +1,1179 @@
+{
+  "name": "dragons-batch-front",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dragons-batch-front",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/front/package.json
+++ b/front/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dragons-batch-front",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -65,6 +65,10 @@ function getCategoryMeta(itemCategoryCode: string) {
   );
 }
 
+function filterByCategory(items: PriceItem[], categoryCode: string) {
+  return items.filter((item) => item.marketCode === categoryCode);
+}
+
 function getStatusTone(status: string) {
   switch (status) {
     case 'COMPLETED':
@@ -86,6 +90,71 @@ function getRankTone(rankName: string) {
   return 'rankDefault';
 }
 
+function toMonthKey(regDay: string) {
+  return regDay.slice(0, 7);
+}
+
+function buildSmoothPath(points: Array<{ x: number; y: number }>) {
+  if (points.length === 0) return '';
+  if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
+  if (points.length === 2) {
+    return `M ${points[0].x} ${points[0].y} L ${points[1].x} ${points[1].y}`;
+  }
+
+  let path = `M ${points[0].x} ${points[0].y}`;
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const p0 = points[index - 1] ?? points[index];
+    const p1 = points[index];
+    const p2 = points[index + 1];
+    const p3 = points[index + 2] ?? p2;
+
+    const control1X = p1.x + (p2.x - p0.x) / 6;
+    const control1Y = p1.y + (p2.y - p0.y) / 6;
+    const control2X = p2.x - (p3.x - p1.x) / 6;
+    const control2Y = p2.y - (p3.y - p1.y) / 6;
+
+    path += ` C ${control1X} ${control1Y}, ${control2X} ${control2Y}, ${p2.x} ${p2.y}`;
+  }
+
+  return path;
+}
+
+function buildAreaPath(points: Array<{ x: number; y: number }>, baselineY: number) {
+  if (points.length === 0) return '';
+  const smoothLine = buildSmoothPath(points);
+  const last = points[points.length - 1];
+  const first = points[0];
+  return `${smoothLine} L ${last.x} ${baselineY} L ${first.x} ${baselineY} Z`;
+}
+
+function createScaledPoints<T extends { value: number }>(
+  rows: T[],
+  width: number,
+  height: number,
+  paddingX: number,
+  paddingTop: number,
+  paddingBottom: number,
+) {
+  const values = rows.map((row) => row.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const rawRange = Math.max(max - min, 1);
+  const paddedMin = Math.max(0, min - rawRange * 0.18);
+  const paddedMax = max + rawRange * 0.18;
+  const scaledRange = Math.max(paddedMax - paddedMin, 1);
+  const usableWidth = width - paddingX * 2;
+  const usableHeight = height - paddingTop - paddingBottom;
+  const stepX = rows.length === 1 ? 0 : usableWidth / (rows.length - 1);
+
+  return rows.map((row, index) => {
+    const x = paddingX + stepX * index;
+    const normalized = (row.value - paddedMin) / scaledRange;
+    const y = paddingTop + usableHeight - usableHeight * normalized;
+    return { ...row, x, y };
+  });
+}
+
 export default function App() {
   const [currentCategory, setCurrentCategory] = useState(DEFAULT_ITEM_CATEGORY);
   const [selectedDate, setSelectedDate] = useState(getToday);
@@ -105,6 +174,10 @@ export default function App() {
   const [isBatchLoading, setIsBatchLoading] = useState(true);
   const [isMonthlySubmitting, setIsMonthlySubmitting] = useState(false);
   const [isHistoryRefreshing, setIsHistoryRefreshing] = useState(false);
+  const [selectedTrendItem, setSelectedTrendItem] = useState<string | null>(null);
+  const [trendItems, setTrendItems] = useState<PriceItem[]>([]);
+  const [isTrendLoading, setIsTrendLoading] = useState(false);
+  const [trendError, setTrendError] = useState<string | null>(null);
 
   const batchPageHref = `${getBackendOrigin()}/batch.html`;
 
@@ -114,14 +187,15 @@ export default function App() {
   );
 
   const chartData = useMemo(() => {
-    const grouped = new Map<string, { total: number; count: number }>();
+    const grouped = new Map<string, { total: number; count: number; unit: string }>();
 
     priceItems.forEach((item) => {
       if (!item.price) return;
 
-      const current = grouped.get(item.itemName) ?? { total: 0, count: 0 };
+      const current = grouped.get(item.itemName) ?? { total: 0, count: 0, unit: item.unit };
       current.total += item.price;
       current.count += 1;
+      if (!current.unit && item.unit) current.unit = item.unit;
       grouped.set(item.itemName, current);
     });
 
@@ -129,6 +203,7 @@ export default function App() {
       .map(([label, value], index) => ({
         label,
         value: Math.round(value.total / value.count),
+        unit: value.unit,
         color: `hsl(${(index * 37 + 120) % 360}, 60%, 55%)`,
       }))
       .sort((left, right) => right.value - left.value)
@@ -138,9 +213,27 @@ export default function App() {
 
     return rows.map((row) => ({
       ...row,
-      ratio: max > 0 ? Math.max((row.value / max) * 100, 10) : 0,
+      ratio: max > 0 ? row.value / max : 0,
     }));
   }, [priceItems]);
+
+  const lineChart = useMemo(() => {
+    if (chartData.length === 0) {
+      return null;
+    }
+
+    const width = 760;
+    const height = 260;
+    const paddingX = 40;
+    const paddingTop = 20;
+    const paddingBottom = 36;
+    const points = createScaledPoints(chartData, width, height, paddingX, paddingTop, paddingBottom);
+    const baselineY = height - paddingBottom;
+    const linePath = buildSmoothPath(points);
+    const areaPath = buildAreaPath(points, baselineY);
+
+    return { width, height, paddingBottom, points, linePath, areaPath };
+  }, [chartData]);
 
   const priceCards = useMemo(() => {
     const seen = new Set<string>();
@@ -151,18 +244,62 @@ export default function App() {
     }).slice(0, 12);
   }, [priceItems]);
 
-  async function loadPrices(task: Promise<{ data: PriceItem[] }>, label: string) {
+  const monthlyTrend = useMemo(() => {
+    const grouped = new Map<string, { total: number; count: number; unit: string }>();
+
+    trendItems.forEach((item) => {
+      const key = toMonthKey(item.regDay);
+      const current = grouped.get(key) ?? { total: 0, count: 0, unit: item.unit };
+      current.total += item.price;
+      current.count += 1;
+      if (!current.unit && item.unit) current.unit = item.unit;
+      grouped.set(key, current);
+    });
+
+    const rows = [...grouped.entries()]
+      .map(([month, value]) => ({
+        month,
+        value: Math.round(value.total / value.count),
+        unit: value.unit,
+      }))
+      .sort((left, right) => left.month.localeCompare(right.month));
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const width = 760;
+    const height = 260;
+    const paddingX = 40;
+    const paddingTop = 20;
+    const paddingBottom = 36;
+    const points = createScaledPoints(rows, width, height, paddingX, paddingTop, paddingBottom);
+    const baselineY = height - paddingBottom;
+    const linePath = buildSmoothPath(points);
+    const areaPath = buildAreaPath(points, baselineY);
+
+    return { width, height, paddingBottom, points, linePath, areaPath };
+  }, [trendItems]);
+
+  async function loadPrices(
+    task: Promise<{ data: PriceItem[] }>,
+    label: string,
+    options?: { categoryCode?: string },
+  ) {
     setIsPriceLoading(true);
     setPriceError(null);
 
     try {
       const response = await task;
-      setPriceItems(response.data);
+      const nextItems = options?.categoryCode ? filterByCategory(response.data, options.categoryCode) : response.data;
+      setPriceItems(nextItems);
       setViewLabel(label);
+      return nextItems;
     } catch (error) {
       setPriceError(error instanceof Error ? error.message : '가격 데이터를 불러오지 못했습니다.');
       setPriceItems([]);
       setViewLabel(label);
+      return [];
     } finally {
       setIsPriceLoading(false);
     }
@@ -171,7 +308,10 @@ export default function App() {
   async function loadLatest(categoryCode = currentCategory) {
     const category = getCategoryMeta(categoryCode);
     setCurrentCategory(categoryCode);
-    await loadPrices(fetchLatestPrices(50), category.label);
+    const nextItems = await loadPrices(fetchLatestPrices(500), category.label, { categoryCode });
+    if (nextItems[0]?.regDay) {
+      setSelectedDate(nextItems[0].regDay);
+    }
   }
 
   async function loadByDate() {
@@ -181,7 +321,9 @@ export default function App() {
     }
 
     const category = getCategoryMeta(currentCategory);
-    await loadPrices(fetchPricesByDate(selectedDate), `${category.label} · ${selectedDate}`);
+    await loadPrices(fetchPricesByDate(selectedDate), `${category.label} · ${selectedDate}`, {
+      categoryCode: currentCategory,
+    });
   }
 
   async function handleSearch(event: FormEvent<HTMLFormElement>) {
@@ -210,6 +352,25 @@ export default function App() {
   useEffect(() => {
     void Promise.all([loadLatest(DEFAULT_ITEM_CATEGORY), refreshBatchOverview()]);
   }, []);
+
+  async function loadItemTrend(itemName: string) {
+    setSelectedTrendItem(itemName);
+    setIsTrendLoading(true);
+    setTrendError(null);
+
+    try {
+      const response = await searchPrices(itemName);
+      const exactItems = response.data.filter(
+        (item) => item.itemName === itemName && item.marketCode === currentCategory,
+      );
+      setTrendItems(exactItems);
+    } catch (error) {
+      setTrendError(error instanceof Error ? error.message : '추이 데이터를 불러오지 못했습니다.');
+      setTrendItems([]);
+    } finally {
+      setIsTrendLoading(false);
+    }
+  }
 
   async function handleMonthlySubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -323,7 +484,7 @@ export default function App() {
                   >
                     {ITEM_CATEGORIES.map((category) => (
                       <option key={category.value} value={category.value}>
-                        {category.value} · {category.label}
+                        {category.label}
                       </option>
                     ))}
                   </select>
@@ -431,7 +592,11 @@ export default function App() {
                           <span className={`${styles.statusChip} ${styles[getStatusTone(item.status)]}`}>{item.status}</span>
                         </div>
                         <div className={styles.batchItemMeta}>
-                          카테고리 {params.itemCategoryCode ?? '-'} · 대상 {year}-{month}
+                          카테고리{' '}
+                          {params.itemCategoryCode
+                            ? getCategoryMeta(params.itemCategoryCode).label
+                            : '-'}{' '}
+                          · 대상 {year}-{month}
                         </div>
                         <div className={styles.batchItemMeta}>
                           시작 {formatDateTime(item.startTime)} · 종료 {formatDateTime(item.endTime)}
@@ -463,15 +628,74 @@ export default function App() {
                 </div>
               ) : (
                 <div className={styles.chartWrap}>
-                  {chartData.map((item) => (
-                    <div className={styles.chartItem} key={item.label}>
-                      <div className={styles.chartValue}>{formatPrice(item.value)}</div>
-                      <div className={styles.chartTrack}>
-                        <div className={styles.chartBar} style={{ height: `${item.ratio}%`, backgroundColor: item.color }} />
+                  {lineChart ? (
+                    <>
+                      <svg
+                        aria-label="가격 비교 꺾은선 차트"
+                        className={styles.lineChartSvg}
+                        viewBox={`0 0 ${lineChart.width} ${lineChart.height}`}
+                      >
+                        <defs>
+                          <linearGradient id="price-line-gradient" x1="0%" x2="100%" y1="0%" y2="0%">
+                            {lineChart.points.map((point) => (
+                              <stop
+                                key={point.label}
+                                offset={`${((point.x - 40) / (lineChart.width - 80)) * 100}%`}
+                                stopColor={point.color}
+                              />
+                            ))}
+                          </linearGradient>
+                        </defs>
+                        <line
+                          className={styles.lineAxis}
+                          x1="40"
+                          x2={String(lineChart.width - 40)}
+                          y1={String(lineChart.height - lineChart.paddingBottom)}
+                          y2={String(lineChart.height - lineChart.paddingBottom)}
+                        />
+                        <path className={styles.lineArea} d={lineChart.areaPath} />
+                        <path className={styles.linePath} d={lineChart.linePath} />
+                        {lineChart.points.map((point) => (
+                          <g className={styles.clickablePoint} key={point.label} onClick={() => void loadItemTrend(point.label)}>
+                            <circle
+                              className={styles.linePoint}
+                              cx={point.x}
+                              cy={point.y}
+                              r="6"
+                              style={{ fill: point.color }}
+                            />
+                            <text className={styles.lineValue} fill={point.color} x={point.x} y={point.y - 12}>
+                              {formatPrice(point.value)}
+                            </text>
+                            <text
+                              className={styles.lineLabel}
+                              fill={point.color}
+                              x={point.x}
+                              y={lineChart.height - 12}
+                            >
+                              {point.label}
+                            </text>
+                          </g>
+                        ))}
+                      </svg>
+                      <div className={styles.lineLegend}>
+                        {lineChart.points.map((point) => (
+                          <button
+                            className={styles.lineLegendItem}
+                            key={point.label}
+                            onClick={() => void loadItemTrend(point.label)}
+                            type="button"
+                          >
+                            <span className={styles.lineLegendDot} style={{ backgroundColor: point.color }} />
+                            <div>
+                              <strong>{point.label}</strong>
+                              <p>{formatPrice(point.value)}</p>
+                            </div>
+                          </button>
+                        ))}
                       </div>
-                      <div className={styles.chartLabel}>{item.label}</div>
-                    </div>
-                  ))}
+                    </>
+                  ) : null}
                 </div>
               )}
             </div>
@@ -492,19 +716,91 @@ export default function App() {
               ) : (
                 <div className={styles.priceGrid}>
                   {priceCards.map((item) => (
-                    <article className={styles.priceCard} key={`${item.itemName}-${item.id}`}>
+                    <button
+                      className={styles.priceCard}
+                      key={`${item.itemName}-${item.id}`}
+                      onClick={() => void loadItemTrend(item.itemName)}
+                      type="button"
+                    >
                       <div className={styles.itemName}>{item.itemName}</div>
                       <div className={styles.itemKind}>{item.kindName || '-'}</div>
                       <div className={styles.itemPrice}>{formatPrice(item.price)}</div>
                       <div className={styles.itemUnit}>{item.unit || '-'}</div>
                       <div className={styles.itemMarket}>📍 {item.marketName || '-'}</div>
-                    </article>
+                    </button>
                   ))}
                 </div>
               )}
             </div>
           </article>
         </section>
+
+        <article className={styles.card}>
+          <div className={styles.cardHead}>
+            <h3>{selectedTrendItem ? `${selectedTrendItem} 월별 추이` : '품목 월별 추이'}</h3>
+            <span className={styles.meta}>
+              {selectedTrendItem
+                ? trendItems.find((item) => item.unit)?.unit
+                  ? `단위 ${trendItems.find((item) => item.unit)?.unit} · 차트나 카드를 클릭해 불러온 결과`
+                  : '차트나 카드를 클릭해 불러온 결과'
+                : '품목을 선택해 주세요'}
+            </span>
+          </div>
+          <div className={styles.cardBody}>
+            {selectedTrendItem == null ? (
+              <div className={styles.emptyState}>차트 포인트나 가격 카드를 클릭하면 월별 변화를 확인할 수 있습니다.</div>
+            ) : isTrendLoading ? (
+              <div className={styles.loadingState}>월별 추이 불러오는 중...</div>
+            ) : trendError ? (
+              <div className={styles.alertError}>오류: {trendError}</div>
+            ) : monthlyTrend == null ? (
+              <div className={styles.emptyState}>선택한 품목의 월별 추이 데이터가 없습니다.</div>
+            ) : (
+              <div className={styles.chartWrap}>
+                <svg
+                  aria-label="품목 월별 변화 추이"
+                  className={styles.lineChartSvg}
+                  viewBox={`0 0 ${monthlyTrend.width} ${monthlyTrend.height}`}
+                >
+                  <defs>
+                    <linearGradient id="monthly-trend-gradient" x1="0%" x2="100%" y1="0%" y2="0%">
+                      <stop offset="0%" stopColor="#2e7d32" />
+                      <stop offset="100%" stopColor="#42a5f5" />
+                    </linearGradient>
+                  </defs>
+                  <line
+                    className={styles.lineAxis}
+                    x1="40"
+                    x2={String(monthlyTrend.width - 40)}
+                    y1={String(monthlyTrend.height - monthlyTrend.paddingBottom)}
+                    y2={String(monthlyTrend.height - monthlyTrend.paddingBottom)}
+                  />
+                  <path className={styles.lineArea} d={monthlyTrend.areaPath} />
+                  <path className={styles.monthlyTrendPath} d={monthlyTrend.linePath} />
+                  {monthlyTrend.points.map((point) => (
+                    <g key={point.month}>
+                      <circle className={styles.monthlyTrendPoint} cx={point.x} cy={point.y} r="6" />
+                      <text className={styles.lineValue} x={point.x} y={point.y - 12}>
+                        {formatPrice(point.value)}
+                      </text>
+                      <text className={styles.monthlyTrendLabel} x={point.x} y={monthlyTrend.height - 12}>
+                        {point.month}
+                      </text>
+                    </g>
+                  ))}
+                </svg>
+                <div className={styles.monthlyTrendLegend}>
+                  {monthlyTrend.points.map((point) => (
+                    <div className={styles.monthlyTrendLegendItem} key={point.month}>
+                      <strong>{point.month}</strong>
+                      <p>{formatPrice(point.value)}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </article>
 
         <article className={styles.card}>
           <div className={styles.cardHead}>
@@ -603,11 +899,22 @@ const styles = {
   statusRunning: 'statusRunning',
   statusIdle: 'statusIdle',
   chartWrap: 'chartWrap',
-  chartItem: 'chartItem',
-  chartValue: 'chartValue',
-  chartTrack: 'chartTrack',
-  chartBar: 'chartBar',
-  chartLabel: 'chartLabel',
+  lineChartSvg: 'lineChartSvg',
+  lineAxis: 'lineAxis',
+  lineArea: 'lineArea',
+  linePath: 'linePath',
+  linePoint: 'linePoint',
+  lineValue: 'lineValue',
+  lineLabel: 'lineLabel',
+  lineLegend: 'lineLegend',
+  lineLegendItem: 'lineLegendItem',
+  lineLegendDot: 'lineLegendDot',
+  clickablePoint: 'clickablePoint',
+  monthlyTrendPath: 'monthlyTrendPath',
+  monthlyTrendPoint: 'monthlyTrendPoint',
+  monthlyTrendLabel: 'monthlyTrendLabel',
+  monthlyTrendLegend: 'monthlyTrendLegend',
+  monthlyTrendLegendItem: 'monthlyTrendLegendItem',
   priceGrid: 'priceGrid',
   priceCard: 'priceCard',
   itemName: 'itemName',

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -357,7 +357,7 @@ export default function App() {
     void Promise.all([loadLatest(DEFAULT_ITEM_CATEGORY), refreshBatchOverview()]);
   }, []);
 
-  async function loadItemTrend(itemName: string) {
+  async function loadItemTrend(itemName: string, itemMarketCode: string) {
     setSelectedTrendItem(itemName);
     setIsTrendLoading(true);
     setTrendError(null);
@@ -365,7 +365,7 @@ export default function App() {
     try {
       const response = await searchPrices(itemName);
       const exactItems = response.data.filter(
-        (item) => item.itemName === itemName && item.marketCode === currentCategory,
+        (item) => item.itemName === itemName && item.marketCode === itemMarketCode,
       );
       setTrendItems(exactItems);
     } catch (error) {
@@ -582,7 +582,9 @@ export default function App() {
               {batchError ? <div className={styles.alertError}>월별 상태 조회 실패: {batchError}</div> : null}
 
               <div className={styles.batchList}>
-                {monthlyHistory.length === 0 ? (
+                {isBatchLoading ? (
+                  <div className={styles.loadingState}>이력 불러오는 중...</div>
+                ) : monthlyHistory.length === 0 ? (
                   <div className={styles.emptyState}>최근 월별 실행 이력이 없습니다.</div>
                 ) : (
                   monthlyHistory.map((item) => {
@@ -661,7 +663,11 @@ export default function App() {
                         <path className={styles.lineArea} d={lineChart.areaPath} />
                         <path className={styles.linePath} d={lineChart.linePath} />
                         {lineChart.points.map((point) => (
-                          <g className={styles.clickablePoint} key={point.label} onClick={() => void loadItemTrend(point.label)}>
+                          <g
+                            className={styles.clickablePoint}
+                            key={point.label}
+                            onClick={() => void loadItemTrend(point.label, currentCategory)}
+                          >
                             <circle
                               className={styles.linePoint}
                               cx={point.x}
@@ -688,7 +694,7 @@ export default function App() {
                           <button
                             className={styles.lineLegendItem}
                             key={point.label}
-                            onClick={() => void loadItemTrend(point.label)}
+                            onClick={() => void loadItemTrend(point.label, currentCategory)}
                             type="button"
                           >
                             <span className={styles.lineLegendDot} style={{ backgroundColor: point.color }} />
@@ -724,7 +730,7 @@ export default function App() {
                     <button
                       className={styles.priceCard}
                       key={`${item.itemName}-${item.id}`}
-                      onClick={() => void loadItemTrend(item.itemName)}
+                      onClick={() => void loadItemTrend(item.itemName, item.marketCode)}
                       type="button"
                     >
                       <div className={styles.itemName}>{item.itemName}</div>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,57 +1,630 @@
-const featureCards = [
-  {
-    title: '일별 가격 조회',
-    description: '기존 날짜 기준 가격 조회 화면을 React 구조로 옮길 준비를 합니다.',
-    status: '준비됨',
-  },
-  {
-    title: '월별 배치 실행',
-    description: 'run-monthly API를 연결할 메인 화면 섹션을 이 위치에 추가합니다.',
-    status: '다음 작업',
-  },
-  {
-    title: '실행 이력 / 상태',
-    description: '배치 상태와 최근 실행 결과를 메인 대시보드에서 함께 보여줄 예정입니다.',
-    status: '예정',
-  },
-];
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import {
+  fetchBatchConfig,
+  fetchBatchStatuses,
+  fetchLatestPrices,
+  fetchPricesByDate,
+  runMonthlyBatch,
+  searchPrices,
+  type BatchConfig,
+  type BatchMonthlyRunResponse,
+  type BatchStatusItem,
+  type PriceItem,
+} from './api';
+import { DEFAULT_ITEM_CATEGORY, ITEM_CATEGORIES } from './constants';
+
+type MonthlyRunForm = {
+  itemCategoryCode: string;
+  year: string;
+  month: string;
+};
+
+function createInitialMonthlyForm(): MonthlyRunForm {
+  const now = new Date();
+  return {
+    itemCategoryCode: DEFAULT_ITEM_CATEGORY,
+    year: String(now.getFullYear()),
+    month: String(now.getMonth() + 1).padStart(2, '0'),
+  };
+}
+
+function getToday() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) return '-';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function formatPrice(price: number | null | undefined) {
+  if (price == null) return '-';
+  return `${price.toLocaleString()}원`;
+}
+
+function getBackendOrigin() {
+  if (typeof window === 'undefined') return '';
+  if (window.location.port === '5173') return 'http://localhost:8080';
+  return window.location.origin;
+}
+
+function getCategoryMeta(itemCategoryCode: string) {
+  return (
+    ITEM_CATEGORIES.find((category) => category.value === itemCategoryCode) ?? {
+      value: itemCategoryCode,
+      label: itemCategoryCode,
+      emoji: '📦',
+    }
+  );
+}
+
+function getStatusTone(status: string) {
+  switch (status) {
+    case 'COMPLETED':
+      return 'statusSuccess';
+    case 'FAILED':
+      return 'statusFailed';
+    case 'STARTING':
+    case 'STARTED':
+      return 'statusRunning';
+    default:
+      return 'statusIdle';
+  }
+}
+
+function getRankTone(rankName: string) {
+  if (rankName.includes('상품')) return 'rankGood';
+  if (rankName.includes('중품')) return 'rankMid';
+  if (rankName.includes('하품')) return 'rankLow';
+  return 'rankDefault';
+}
 
 export default function App() {
+  const [currentCategory, setCurrentCategory] = useState(DEFAULT_ITEM_CATEGORY);
+  const [selectedDate, setSelectedDate] = useState(getToday);
+  const [searchInput, setSearchInput] = useState('');
+  const [viewLabel, setViewLabel] = useState(getCategoryMeta(DEFAULT_ITEM_CATEGORY).label);
+
+  const [priceItems, setPriceItems] = useState<PriceItem[]>([]);
+  const [isPriceLoading, setIsPriceLoading] = useState(true);
+  const [priceError, setPriceError] = useState<string | null>(null);
+
+  const [batchConfig, setBatchConfig] = useState<BatchConfig | null>(null);
+  const [batchStatuses, setBatchStatuses] = useState<BatchStatusItem[]>([]);
+  const [latestMonthlyRun, setLatestMonthlyRun] = useState<BatchMonthlyRunResponse | null>(null);
+  const [monthlyForm, setMonthlyForm] = useState(createInitialMonthlyForm);
+  const [batchError, setBatchError] = useState<string | null>(null);
+  const [monthlyRunError, setMonthlyRunError] = useState<string | null>(null);
+  const [isBatchLoading, setIsBatchLoading] = useState(true);
+  const [isMonthlySubmitting, setIsMonthlySubmitting] = useState(false);
+  const [isHistoryRefreshing, setIsHistoryRefreshing] = useState(false);
+
+  const batchPageHref = `${getBackendOrigin()}/batch.html`;
+
+  const monthlyHistory = useMemo(
+    () => batchStatuses.filter((item) => item.jobName === 'kamisMonthlyPriceJob').slice(0, 5),
+    [batchStatuses],
+  );
+
+  const chartData = useMemo(() => {
+    const grouped = new Map<string, { total: number; count: number }>();
+
+    priceItems.forEach((item) => {
+      if (!item.price) return;
+
+      const current = grouped.get(item.itemName) ?? { total: 0, count: 0 };
+      current.total += item.price;
+      current.count += 1;
+      grouped.set(item.itemName, current);
+    });
+
+    const rows = [...grouped.entries()]
+      .map(([label, value], index) => ({
+        label,
+        value: Math.round(value.total / value.count),
+        color: `hsl(${(index * 37 + 120) % 360}, 60%, 55%)`,
+      }))
+      .sort((left, right) => right.value - left.value)
+      .slice(0, 10);
+
+    const max = rows[0]?.value ?? 0;
+
+    return rows.map((row) => ({
+      ...row,
+      ratio: max > 0 ? Math.max((row.value / max) * 100, 10) : 0,
+    }));
+  }, [priceItems]);
+
+  const priceCards = useMemo(() => {
+    const seen = new Set<string>();
+    return priceItems.filter((item) => {
+      if (seen.has(item.itemName)) return false;
+      seen.add(item.itemName);
+      return true;
+    }).slice(0, 12);
+  }, [priceItems]);
+
+  async function loadPrices(task: Promise<{ data: PriceItem[] }>, label: string) {
+    setIsPriceLoading(true);
+    setPriceError(null);
+
+    try {
+      const response = await task;
+      setPriceItems(response.data);
+      setViewLabel(label);
+    } catch (error) {
+      setPriceError(error instanceof Error ? error.message : '가격 데이터를 불러오지 못했습니다.');
+      setPriceItems([]);
+      setViewLabel(label);
+    } finally {
+      setIsPriceLoading(false);
+    }
+  }
+
+  async function loadLatest(categoryCode = currentCategory) {
+    const category = getCategoryMeta(categoryCode);
+    setCurrentCategory(categoryCode);
+    await loadPrices(fetchLatestPrices(50), category.label);
+  }
+
+  async function loadByDate() {
+    if (!selectedDate) {
+      await loadLatest();
+      return;
+    }
+
+    const category = getCategoryMeta(currentCategory);
+    await loadPrices(fetchPricesByDate(selectedDate), `${category.label} · ${selectedDate}`);
+  }
+
+  async function handleSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const keyword = searchInput.trim();
+    if (!keyword) return;
+    await loadPrices(searchPrices(keyword), `"${keyword}" 검색 결과`);
+  }
+
+  async function refreshBatchOverview() {
+    setIsHistoryRefreshing(true);
+    setBatchError(null);
+
+    try {
+      const [config, statuses] = await Promise.all([fetchBatchConfig(), fetchBatchStatuses(10)]);
+      setBatchConfig(config);
+      setBatchStatuses(statuses.data);
+    } catch (error) {
+      setBatchError(error instanceof Error ? error.message : '배치 상태를 불러오지 못했습니다.');
+    } finally {
+      setIsBatchLoading(false);
+      setIsHistoryRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    void Promise.all([loadLatest(DEFAULT_ITEM_CATEGORY), refreshBatchOverview()]);
+  }, []);
+
+  async function handleMonthlySubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setMonthlyRunError(null);
+    setIsMonthlySubmitting(true);
+
+    try {
+      const result = await runMonthlyBatch(monthlyForm);
+      setLatestMonthlyRun(result);
+      await refreshBatchOverview();
+    } catch (error) {
+      setMonthlyRunError(error instanceof Error ? error.message : '월별 배치 실행에 실패했습니다.');
+    } finally {
+      setIsMonthlySubmitting(false);
+    }
+  }
+
+  function updateMonthlyField<Key extends keyof MonthlyRunForm>(key: Key, value: MonthlyRunForm[Key]) {
+    setMonthlyForm((current) => ({
+      ...current,
+      [key]: value,
+    }));
+  }
+
+  function syncMonthlyCategory() {
+    setMonthlyForm((current) => ({
+      ...current,
+      itemCategoryCode: currentCategory,
+    }));
+  }
+
   return (
-    <div className="app-shell">
-      <header className="hero">
-        <div>
-          <p className="eyebrow">DRAGONS BATCH</p>
-          <h1>KAMIS 가격 조회 프론트엔드</h1>
-          <p className="hero-copy">
-            root/front 기준으로 React + TypeScript 구조를 먼저 만들었습니다.
-            다음 단계에서 메인 화면에 월별 조회/배치 UI를 붙이면 됩니다.
-          </p>
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.headerLeft}>
+          <div className={styles.logo}>🌾</div>
+          <div>
+            <h1>KAMIS 농산물 가격 정보</h1>
+            <p>농산물유통정보 실시간 가격 조회</p>
+          </div>
         </div>
+        <nav className={styles.headerNav}>
+          <a href={batchPageHref}>⚙️ 배치 관리</a>
+        </nav>
       </header>
 
-      <main className="content">
-        <section className="panel panel-accent">
-          <h2>현재 생성된 범위</h2>
-          <ul className="check-list">
-            <li>Vite 기반 React + TypeScript 엔트리</li>
-            <li>front/index.html 진입점</li>
-            <li>메인 대시보드용 기본 레이아웃</li>
-          </ul>
+      <section className={styles.hero}>
+        <h2>오늘의 농산물 가격은?</h2>
+        <p>품목명을 검색하거나 카테고리를 선택해 가격 정보를 확인하세요</p>
+        <form className={styles.searchBar} onSubmit={handleSearch}>
+          <input
+            placeholder="예: 배추, 사과, 쌀..."
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+          <button type="submit">🔍 검색</button>
+        </form>
+      </section>
+
+      <main className={styles.main}>
+        <div className={styles.sectionTitle}>📂 카테고리별 가격 조회</div>
+        <div className={styles.categoryTabs}>
+          {ITEM_CATEGORIES.map((category) => (
+            <button
+              className={`${styles.categoryTab} ${currentCategory === category.value ? styles.categoryTabActive : ''}`}
+              key={category.value}
+              onClick={() => void loadLatest(category.value)}
+              type="button"
+            >
+              <span>{category.emoji}</span>
+              {category.label}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.filterRow}>
+          <label htmlFor="main-date">조회 날짜</label>
+          <input
+            id="main-date"
+            type="date"
+            value={selectedDate}
+            onChange={(event) => setSelectedDate(event.target.value)}
+          />
+          <button className={styles.btnGreen} onClick={() => void loadByDate()} type="button">
+            조회
+          </button>
+          <button className={styles.btnOutline} onClick={() => void loadLatest()} type="button">
+            최신 데이터
+          </button>
+        </div>
+
+        <div className={styles.sectionTitle}>🗓️ 월별 가격 수집</div>
+        <section className={styles.gridTwo}>
+          <article className={styles.card}>
+            <div className={styles.cardHead}>
+              <h3>월별 배치 실행</h3>
+              <span className={styles.meta}>POST /api/batch/run-monthly</span>
+            </div>
+            <div className={styles.cardBody}>
+              <p className={styles.hint}>
+                기존 메인 화면에서 바로 월별 데이터를 수집합니다. 연/월은 <strong>year / month</strong> 형식으로
+                전송됩니다.
+              </p>
+              <form className={styles.monthlyForm} onSubmit={handleMonthlySubmit}>
+                <div className={styles.field}>
+                  <label htmlFor="monthly-category">카테고리</label>
+                  <select
+                    id="monthly-category"
+                    value={monthlyForm.itemCategoryCode}
+                    onChange={(event) => updateMonthlyField('itemCategoryCode', event.target.value)}
+                  >
+                    {ITEM_CATEGORIES.map((category) => (
+                      <option key={category.value} value={category.value}>
+                        {category.value} · {category.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className={styles.field}>
+                  <label htmlFor="monthly-year">연도</label>
+                  <input
+                    id="monthly-year"
+                    inputMode="numeric"
+                    maxLength={4}
+                    placeholder="2024"
+                    value={monthlyForm.year}
+                    onChange={(event) => updateMonthlyField('year', event.target.value.replace(/\D/g, '').slice(0, 4))}
+                  />
+                </div>
+                <div className={styles.field}>
+                  <label htmlFor="monthly-month">월</label>
+                  <input
+                    id="monthly-month"
+                    inputMode="numeric"
+                    maxLength={2}
+                    placeholder="01"
+                    value={monthlyForm.month}
+                    onChange={(event) =>
+                      updateMonthlyField('month', event.target.value.replace(/\D/g, '').slice(0, 2))
+                    }
+                  />
+                </div>
+                <button className={styles.btnGreen} disabled={isMonthlySubmitting} type="submit">
+                  {isMonthlySubmitting ? '실행 중...' : '월별 실행'}
+                </button>
+                <button className={styles.btnOutline} onClick={syncMonthlyCategory} type="button">
+                  현재 탭 반영
+                </button>
+              </form>
+
+              <div className={styles.resultBox}>
+                {monthlyRunError ? (
+                  <div className={styles.alertError}>월별 배치 실행 실패: {monthlyRunError}</div>
+                ) : latestMonthlyRun ? (
+                  <>
+                    <strong>{latestMonthlyRun.status}</strong>
+                    실행 ID {latestMonthlyRun.jobExecutionId} · 카테고리 {latestMonthlyRun.itemCategoryCode} · 대상{' '}
+                    {latestMonthlyRun.year}-{latestMonthlyRun.month}
+                    <div className={styles.metaLine}>
+                      시작 {formatDateTime(latestMonthlyRun.startTime)} · 종료 {formatDateTime(latestMonthlyRun.endTime)}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <strong>대기 중</strong>
+                    월별 배치를 실행하면 여기에서 성공/실패, 실행 ID, 대상 월을 확인할 수 있습니다.
+                  </>
+                )}
+              </div>
+            </div>
+          </article>
+
+          <article className={styles.card}>
+            <div className={styles.cardHead}>
+              <h3>월별 배치 상태</h3>
+              <span className={styles.meta}>GET /api/batch/config · GET /api/batch/status</span>
+            </div>
+            <div className={styles.cardBody}>
+              <div className={styles.batchSummary}>
+                <div className={styles.summaryPill}>
+                  <span className={styles.summaryLabel}>API 설정</span>
+                  <span className={styles.summaryValue}>
+                    {batchConfig == null
+                      ? '확인 중...'
+                      : batchConfig.apiConfigured
+                        ? batchConfig.mockMode
+                          ? 'Mock 모드'
+                          : '준비 완료'
+                        : '설정 필요'}
+                  </span>
+                </div>
+                <div className={styles.summaryPill}>
+                  <span className={styles.summaryLabel}>최근 월별 실행 수</span>
+                  <span className={styles.summaryValue}>{isBatchLoading ? '확인 중...' : `${monthlyHistory.length}건`}</span>
+                </div>
+              </div>
+
+              <div className={styles.batchActionRow}>
+                <button className={styles.btnOutline} onClick={() => void refreshBatchOverview()} type="button">
+                  {isHistoryRefreshing ? '새로고침 중...' : '이력 새로고침'}
+                </button>
+              </div>
+
+              {batchError ? <div className={styles.alertError}>월별 상태 조회 실패: {batchError}</div> : null}
+
+              <div className={styles.batchList}>
+                {monthlyHistory.length === 0 ? (
+                  <div className={styles.emptyState}>최근 월별 실행 이력이 없습니다.</div>
+                ) : (
+                  monthlyHistory.map((item) => {
+                    const params = item.params ?? {};
+                    const year = params.year ?? params.yyyy ?? '-';
+                    const month = params.month ?? params.mm ?? '-';
+
+                    return (
+                      <article className={styles.batchItem} key={item.jobExecutionId}>
+                        <div className={styles.batchItemHead}>
+                          <div className={styles.batchItemTitle}>실행 #{item.jobExecutionId}</div>
+                          <span className={`${styles.statusChip} ${styles[getStatusTone(item.status)]}`}>{item.status}</span>
+                        </div>
+                        <div className={styles.batchItemMeta}>
+                          카테고리 {params.itemCategoryCode ?? '-'} · 대상 {year}-{month}
+                        </div>
+                        <div className={styles.batchItemMeta}>
+                          시작 {formatDateTime(item.startTime)} · 종료 {formatDateTime(item.endTime)}
+                        </div>
+                      </article>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </article>
         </section>
 
-        <section className="feature-grid">
-          {featureCards.map((card) => (
-            <article className="panel feature-card" key={card.title}>
-              <div className="feature-head">
-                <h3>{card.title}</h3>
-                <span className="badge">{card.status}</span>
-              </div>
-              <p>{card.description}</p>
-            </article>
-          ))}
+        <section className={styles.gridTwo}>
+          <article className={styles.card}>
+            <div className={styles.cardHead}>
+              <h3>{viewLabel} 가격 비교 차트</h3>
+              <span className={styles.meta}>{priceItems.length}건</span>
+            </div>
+            <div className={styles.cardBody}>
+              {isPriceLoading ? (
+                <div className={styles.loadingState}>데이터 불러오는 중...</div>
+              ) : priceError ? (
+                <div className={styles.alertError}>오류: {priceError}</div>
+              ) : chartData.length === 0 ? (
+                <div className={styles.emptyState}>
+                  먼저 데이터를 수집해주세요.
+                  <small>배치를 실행하면 데이터가 저장됩니다.</small>
+                </div>
+              ) : (
+                <div className={styles.chartWrap}>
+                  {chartData.map((item) => (
+                    <div className={styles.chartItem} key={item.label}>
+                      <div className={styles.chartValue}>{formatPrice(item.value)}</div>
+                      <div className={styles.chartTrack}>
+                        <div className={styles.chartBar} style={{ height: `${item.ratio}%`, backgroundColor: item.color }} />
+                      </div>
+                      <div className={styles.chartLabel}>{item.label}</div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </article>
+
+          <article className={styles.card}>
+            <div className={styles.cardHead}>
+              <h3>품목 가격 카드</h3>
+              <span className={styles.meta}>{priceItems.length}건</span>
+            </div>
+            <div className={styles.cardBody}>
+              {isPriceLoading ? (
+                <div className={styles.loadingState}>데이터 불러오는 중...</div>
+              ) : priceError ? (
+                <div className={styles.alertError}>오류: {priceError}</div>
+              ) : priceCards.length === 0 ? (
+                <div className={styles.emptyState}>데이터 없음</div>
+              ) : (
+                <div className={styles.priceGrid}>
+                  {priceCards.map((item) => (
+                    <article className={styles.priceCard} key={`${item.itemName}-${item.id}`}>
+                      <div className={styles.itemName}>{item.itemName}</div>
+                      <div className={styles.itemKind}>{item.kindName || '-'}</div>
+                      <div className={styles.itemPrice}>{formatPrice(item.price)}</div>
+                      <div className={styles.itemUnit}>{item.unit || '-'}</div>
+                      <div className={styles.itemMarket}>📍 {item.marketName || '-'}</div>
+                    </article>
+                  ))}
+                </div>
+              )}
+            </div>
+          </article>
         </section>
+
+        <article className={styles.card}>
+          <div className={styles.cardHead}>
+            <h3>{viewLabel} 가격 목록</h3>
+            <span className={styles.meta}>총 {priceItems.length}건</span>
+          </div>
+          <div className={styles.tableCardBody}>
+            {isPriceLoading ? (
+              <div className={styles.loadingState}>불러오는 중...</div>
+            ) : priceError ? (
+              <div className={styles.alertError}>오류: {priceError}</div>
+            ) : priceItems.length === 0 ? (
+              <div className={styles.emptyState}>데이터가 없습니다.</div>
+            ) : (
+              <div className={styles.tableWrap}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>품목</th>
+                      <th>품종</th>
+                      <th>등급</th>
+                      <th>시장</th>
+                      <th>가격</th>
+                      <th>단위</th>
+                      <th>날짜</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {priceItems.map((item) => (
+                      <tr key={item.id}>
+                        <td>
+                          <strong>{item.itemName || '-'}</strong>
+                        </td>
+                        <td>{item.kindName || '-'}</td>
+                        <td>
+                          <span className={`${styles.rankBadge} ${styles[getRankTone(item.rankName)]}`}>
+                            {item.rankName || '-'}
+                          </span>
+                        </td>
+                        <td>{item.marketName || '-'}</td>
+                        <td className={styles.priceValue}>{formatPrice(item.price)}</td>
+                        <td>{item.unit || '-'}</td>
+                        <td>{item.regDay || '-'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </article>
       </main>
     </div>
   );
 }
+
+const styles = {
+  page: 'page',
+  header: 'header',
+  headerLeft: 'headerLeft',
+  logo: 'logo',
+  headerNav: 'headerNav',
+  hero: 'hero',
+  searchBar: 'searchBar',
+  main: 'main',
+  sectionTitle: 'sectionTitle',
+  categoryTabs: 'categoryTabs',
+  categoryTab: 'categoryTab',
+  categoryTabActive: 'categoryTabActive',
+  filterRow: 'filterRow',
+  btnGreen: 'btnGreen',
+  btnOutline: 'btnOutline',
+  gridTwo: 'gridTwo',
+  card: 'card',
+  cardHead: 'cardHead',
+  cardBody: 'cardBody',
+  meta: 'meta',
+  monthlyForm: 'monthlyForm',
+  field: 'field',
+  hint: 'hint',
+  resultBox: 'resultBox',
+  metaLine: 'metaLine',
+  batchSummary: 'batchSummary',
+  summaryPill: 'summaryPill',
+  summaryLabel: 'summaryLabel',
+  summaryValue: 'summaryValue',
+  batchActionRow: 'batchActionRow',
+  batchList: 'batchList',
+  batchItem: 'batchItem',
+  batchItemHead: 'batchItemHead',
+  batchItemTitle: 'batchItemTitle',
+  batchItemMeta: 'batchItemMeta',
+  statusChip: 'statusChip',
+  statusSuccess: 'statusSuccess',
+  statusFailed: 'statusFailed',
+  statusRunning: 'statusRunning',
+  statusIdle: 'statusIdle',
+  chartWrap: 'chartWrap',
+  chartItem: 'chartItem',
+  chartValue: 'chartValue',
+  chartTrack: 'chartTrack',
+  chartBar: 'chartBar',
+  chartLabel: 'chartLabel',
+  priceGrid: 'priceGrid',
+  priceCard: 'priceCard',
+  itemName: 'itemName',
+  itemKind: 'itemKind',
+  itemPrice: 'itemPrice',
+  itemUnit: 'itemUnit',
+  itemMarket: 'itemMarket',
+  tableCardBody: 'tableCardBody',
+  tableWrap: 'tableWrap',
+  table: 'table',
+  priceValue: 'priceValue',
+  rankBadge: 'rankBadge',
+  rankGood: 'rankGood',
+  rankMid: 'rankMid',
+  rankLow: 'rankLow',
+  rankDefault: 'rankDefault',
+  alertError: 'alertError',
+  loadingState: 'loadingState',
+  emptyState: 'emptyState',
+} as const;

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -29,7 +29,11 @@ function createInitialMonthlyForm(): MonthlyRunForm {
 }
 
 function getToday() {
-  return new Date().toISOString().slice(0, 10);
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 function formatDateTime(value: string | null) {
@@ -422,6 +426,7 @@ export default function App() {
         <p>품목명을 검색하거나 카테고리를 선택해 가격 정보를 확인하세요</p>
         <form className={styles.searchBar} onSubmit={handleSearch}>
           <input
+            aria-label="품목명 검색"
             placeholder="예: 배추, 사과, 쌀..."
             value={searchInput}
             onChange={(event) => setSearchInput(event.target.value)}

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -560,11 +560,11 @@ export default function App() {
                   <span className={styles.summaryValue}>
                     {batchConfig == null
                       ? '확인 중...'
-                      : batchConfig.apiConfigured
-                        ? batchConfig.mockMode
-                          ? 'Mock 모드'
-                          : '준비 완료'
-                        : '설정 필요'}
+                      : batchConfig.mockMode
+                        ? 'Mock 모드'
+                        : batchConfig.apiConfigured
+                          ? '준비 완료'
+                          : '설정 필요'}
                   </span>
                 </div>
                 <div className={styles.summaryPill}>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,0 +1,57 @@
+const featureCards = [
+  {
+    title: '일별 가격 조회',
+    description: '기존 날짜 기준 가격 조회 화면을 React 구조로 옮길 준비를 합니다.',
+    status: '준비됨',
+  },
+  {
+    title: '월별 배치 실행',
+    description: 'run-monthly API를 연결할 메인 화면 섹션을 이 위치에 추가합니다.',
+    status: '다음 작업',
+  },
+  {
+    title: '실행 이력 / 상태',
+    description: '배치 상태와 최근 실행 결과를 메인 대시보드에서 함께 보여줄 예정입니다.',
+    status: '예정',
+  },
+];
+
+export default function App() {
+  return (
+    <div className="app-shell">
+      <header className="hero">
+        <div>
+          <p className="eyebrow">DRAGONS BATCH</p>
+          <h1>KAMIS 가격 조회 프론트엔드</h1>
+          <p className="hero-copy">
+            root/front 기준으로 React + TypeScript 구조를 먼저 만들었습니다.
+            다음 단계에서 메인 화면에 월별 조회/배치 UI를 붙이면 됩니다.
+          </p>
+        </div>
+      </header>
+
+      <main className="content">
+        <section className="panel panel-accent">
+          <h2>현재 생성된 범위</h2>
+          <ul className="check-list">
+            <li>Vite 기반 React + TypeScript 엔트리</li>
+            <li>front/index.html 진입점</li>
+            <li>메인 대시보드용 기본 레이아웃</li>
+          </ul>
+        </section>
+
+        <section className="feature-grid">
+          {featureCards.map((card) => (
+            <article className="panel feature-card" key={card.title}>
+              <div className="feature-head">
+                <h3>{card.title}</h3>
+                <span className="badge">{card.status}</span>
+              </div>
+              <p>{card.description}</p>
+            </article>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/front/src/api.ts
+++ b/front/src/api.ts
@@ -1,0 +1,125 @@
+export type ApiResponse<T> = {
+  success: boolean;
+  data: T | null;
+  message: string | null;
+};
+
+export type BatchConfig = {
+  apiConfigured: boolean;
+  mockMode: boolean;
+  baseUrl: string;
+  certKeySet: boolean;
+  certIdSet: boolean;
+};
+
+export type BatchMonthlyRunResponse = {
+  jobExecutionId: number;
+  status: string;
+  startTime: string | null;
+  endTime: string | null;
+  itemCategoryCode: string;
+  year: string;
+  month: string;
+  mockMode: boolean;
+};
+
+export type BatchStatusItem = {
+  jobInstanceId: number;
+  jobExecutionId: number;
+  jobName: string;
+  status: string;
+  startTime: string | null;
+  endTime: string | null;
+  exitCode: string | null;
+  params: Record<string, string>;
+};
+
+export type BatchStatusResponse = {
+  count: number;
+  mockMode: boolean;
+  apiConfigured: boolean;
+  data: BatchStatusItem[];
+};
+
+export type PriceItem = {
+  id: number;
+  itemCode: string;
+  itemName: string;
+  kindCode: string;
+  kindName: string;
+  marketCode: string;
+  marketName: string;
+  rankCode: string;
+  rankName: string;
+  price: number;
+  unit: string;
+  regDay: string;
+  createdAt: string;
+};
+
+export type PriceListResponse = {
+  count: number;
+  data: PriceItem[];
+};
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, {
+    headers: {
+      Accept: 'application/json',
+      ...init?.headers,
+    },
+    ...init,
+  });
+
+  let payload: ApiResponse<T> | null = null;
+  try {
+    payload = (await response.json()) as ApiResponse<T>;
+  } catch {
+    throw new Error('서버 응답을 해석하지 못했습니다.');
+  }
+
+  if (!response.ok || !payload.success || payload.data == null) {
+    throw new Error(payload.message ?? '요청 처리에 실패했습니다.');
+  }
+
+  return payload.data;
+}
+
+export function fetchBatchConfig() {
+  return request<BatchConfig>('/api/batch/config');
+}
+
+export function fetchBatchStatuses(limit = 10) {
+  const searchParams = new URLSearchParams({ limit: String(limit) });
+  return request<BatchStatusResponse>(`/api/batch/status?${searchParams.toString()}`);
+}
+
+export function runMonthlyBatch(input: {
+  itemCategoryCode: string;
+  year: string;
+  month: string;
+}) {
+  const body = new URLSearchParams(input);
+  return request<BatchMonthlyRunResponse>('/api/batch/run-monthly', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    },
+    body,
+  });
+}
+
+export function fetchLatestPrices(limit = 50) {
+  const searchParams = new URLSearchParams({ limit: String(limit) });
+  return request<PriceListResponse>(`/api/prices/latest?${searchParams.toString()}`);
+}
+
+export function fetchPricesByDate(regDay: string) {
+  const searchParams = new URLSearchParams({ regDay });
+  return request<PriceListResponse>(`/api/prices?${searchParams.toString()}`);
+}
+
+export function searchPrices(itemName: string) {
+  const searchParams = new URLSearchParams({ itemName });
+  return request<PriceListResponse>(`/api/prices/search?${searchParams.toString()}`);
+}

--- a/front/src/constants.ts
+++ b/front/src/constants.ts
@@ -7,4 +7,6 @@ export const ITEM_CATEGORIES = [
   { value: '600', label: '수산물', emoji: '🐟' },
 ] as const;
 
-export const DEFAULT_ITEM_CATEGORY = '100';
+export type ItemCategoryCode = (typeof ITEM_CATEGORIES)[number]['value'];
+
+export const DEFAULT_ITEM_CATEGORY: ItemCategoryCode = ITEM_CATEGORIES[0]?.value ?? '100';

--- a/front/src/constants.ts
+++ b/front/src/constants.ts
@@ -1,0 +1,10 @@
+export const ITEM_CATEGORIES = [
+  { value: '100', label: '식량작물', emoji: '🌾' },
+  { value: '200', label: '채소류', emoji: '🥬' },
+  { value: '300', label: '특용작물', emoji: '🌿' },
+  { value: '400', label: '과일류', emoji: '🍎' },
+  { value: '500', label: '축산물', emoji: '🥩' },
+  { value: '600', label: '수산물', emoji: '🐟' },
+] as const;
+
+export const DEFAULT_ITEM_CATEGORY = '100';

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -1,0 +1,148 @@
+:root {
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #e5eef7;
+  background: #0f172a;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.24), transparent 32%),
+    linear-gradient(180deg, #0f172a 0%, #111827 100%);
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.hero {
+  padding: 72px 24px 32px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.content {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: #7dd3fc;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.1;
+}
+
+.hero-copy {
+  max-width: 760px;
+  margin: 16px 0 0;
+  color: #cbd5e1;
+  font-size: 1rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 20px 50px rgba(2, 6, 23, 0.28);
+  backdrop-filter: blur(16px);
+}
+
+.panel-accent {
+  margin-bottom: 24px;
+}
+
+.panel-accent h2 {
+  margin: 0 0 16px;
+  font-size: 1.25rem;
+}
+
+.check-list {
+  margin: 0;
+  padding-left: 20px;
+  color: #cbd5e1;
+}
+
+.check-list li + li {
+  margin-top: 8px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.feature-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.feature-card p {
+  margin: 14px 0 0;
+  color: #cbd5e1;
+}
+
+.feature-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(125, 211, 252, 0.16);
+  color: #7dd3fc;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding-top: 56px;
+  }
+
+  .content {
+    padding-inline: 16px;
+  }
+
+  .panel {
+    padding: 20px;
+  }
+}

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -1,16 +1,27 @@
 :root {
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.5;
+  --bg: #f0f4f8;
+  --white: #ffffff;
+  --surface2: #f7fafc;
+  --border: #e2e8f0;
+  --accent: #2e7d32;
+  --accent-light: #e8f5e9;
+  --accent2: #f57c00;
+  --text: #1a202c;
+  --text-muted: #718096;
+  --warn: #f59e0b;
+  --red: #c62828;
+  --radius: 12px;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  font-family: 'Pretendard', 'Segoe UI', system-ui, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
   font-weight: 400;
-  color: #e5eef7;
-  background: #0f172a;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -18,131 +29,630 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at top, rgba(59, 130, 246, 0.24), transparent 32%),
-    linear-gradient(180deg, #0f172a 0%, #111827 100%);
+  background: var(--bg);
+  color: var(--text);
 }
 
 button,
 input,
-textarea,
 select {
   font: inherit;
+}
+
+button {
+  border: 0;
+}
+
+a {
+  color: inherit;
 }
 
 #root {
   min-height: 100vh;
 }
 
-.app-shell {
+.page {
   min-height: 100vh;
 }
 
-.hero {
-  padding: 72px 24px 32px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+.header {
+  background: var(--accent);
+  color: white;
+  padding: 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
 }
 
-.content {
-  max-width: 1120px;
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo {
+  font-size: 24px;
+}
+
+.headerLeft h1 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.headerLeft p {
+  margin: 0;
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+.headerNav a {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  transition: all 0.15s;
+}
+
+.headerNav a:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+}
+
+.hero {
+  background: linear-gradient(135deg, #1b5e20 0%, #2e7d32 60%, #388e3c 100%);
+  color: white;
+  padding: 48px 32px 40px;
+  text-align: center;
+}
+
+.hero h2 {
+  margin: 0 0 8px;
+  font-size: 28px;
+  font-weight: 800;
+}
+
+.hero p {
+  margin: 0 0 28px;
+  font-size: 14px;
+  opacity: 0.85;
+}
+
+.searchBar {
+  display: flex;
+  gap: 8px;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.searchBar input {
+  flex: 1;
+  min-width: 0;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: none;
+  font-size: 14px;
+  outline: none;
+  color: var(--text);
+}
+
+.searchBar button {
+  padding: 12px 20px;
+  background: var(--accent2);
+  color: white;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.main {
+  max-width: 1200px;
   margin: 0 auto;
   padding: 32px 24px 48px;
 }
 
-.eyebrow {
-  margin: 0 0 8px;
-  font-size: 12px;
+.sectionTitle {
+  font-size: 16px;
   font-weight: 700;
-  letter-spacing: 0.14em;
-  color: #7dd3fc;
+  margin-bottom: 14px;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-h1 {
-  margin: 0;
-  font-size: clamp(2rem, 5vw, 3.4rem);
-  line-height: 1.1;
-}
-
-.hero-copy {
-  max-width: 760px;
-  margin: 16px 0 0;
-  color: #cbd5e1;
-  font-size: 1rem;
-}
-
-.panel {
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 20px;
-  padding: 24px;
-  box-shadow: 0 20px 50px rgba(2, 6, 23, 0.28);
-  backdrop-filter: blur(16px);
-}
-
-.panel-accent {
+.categoryTabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
   margin-bottom: 24px;
 }
 
-.panel-accent h2 {
-  margin: 0 0 16px;
-  font-size: 1.25rem;
+.categoryTab {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 50px;
+  background: var(--white);
+  border: 2px solid var(--border);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  transition: all 0.15s;
+  box-shadow: var(--shadow);
 }
 
-.check-list {
-  margin: 0;
-  padding-left: 20px;
-  color: #cbd5e1;
+.categoryTab:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
-.check-list li + li {
-  margin-top: 8px;
+.categoryTabActive {
+  border-color: var(--accent);
+  background: var(--accent-light);
+  color: var(--accent);
 }
 
-.feature-grid {
+.filterRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.filterRow label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.filterRow input,
+.field input,
+.field select {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text);
+  outline: none;
+  background: var(--white);
+}
+
+.gridTwo {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 16px;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
 }
 
-.feature-card h3 {
-  margin: 0;
-  font-size: 1.05rem;
+.card {
+  background: var(--white);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
 }
 
-.feature-card p {
-  margin: 14px 0 0;
-  color: #cbd5e1;
-}
-
-.feature-head {
+.cardHead {
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(125, 211, 252, 0.16);
-  color: #7dd3fc;
-  font-size: 0.8rem;
+.cardHead h3 {
+  margin: 0;
+  font-size: 14px;
   font-weight: 700;
 }
 
-@media (max-width: 640px) {
-  .hero {
-    padding-top: 56px;
+.meta {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.cardBody {
+  padding: 20px;
+}
+
+.tableCardBody {
+  padding: 0;
+}
+
+.hint {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.monthlyForm {
+  display: grid;
+  grid-template-columns: 1.2fr 0.9fr 0.8fr auto auto;
+  gap: 10px;
+  align-items: end;
+  margin-bottom: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.btnGreen,
+.btnOutline {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btnGreen {
+  background: var(--accent);
+  color: white;
+}
+
+.btnGreen:hover {
+  background: #1b5e20;
+}
+
+.btnOutline {
+  background: white;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.btnOutline:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.btnGreen:disabled,
+.btnOutline:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.resultBox {
+  min-height: 88px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  font-size: 13px;
+}
+
+.resultBox strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+
+.metaLine {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+.batchSummary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.summaryPill {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  background: var(--surface2);
+}
+
+.summaryLabel {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.summaryValue {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.batchActionRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.batchList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.batchItem {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  background: var(--surface2);
+}
+
+.batchItemHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.batchItemTitle {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.batchItemMeta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.statusChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.statusSuccess {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.statusFailed {
+  background: #ffebee;
+  color: #c62828;
+}
+
+.statusRunning {
+  background: #fff8e1;
+  color: #e65100;
+}
+
+.statusIdle {
+  background: #eceff1;
+  color: #546e7a;
+}
+
+.chartWrap {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(68px, 1fr));
+  gap: 12px;
+  min-height: 300px;
+  align-items: end;
+}
+
+.chartItem {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  justify-content: end;
+  min-height: 300px;
+}
+
+.chartValue {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.chartTrack {
+  width: 100%;
+  max-width: 56px;
+  height: 220px;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+  border-radius: 10px;
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.chartBar {
+  width: 100%;
+  border-radius: 10px 10px 0 0;
+}
+
+.chartLabel {
+  font-size: 11px;
+  text-align: center;
+  color: var(--text-muted);
+  word-break: keep-all;
+}
+
+.priceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.priceCard {
+  background: var(--bg);
+  border-radius: 10px;
+  padding: 14px;
+  border: 1px solid var(--border);
+}
+
+.itemName {
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.itemKind,
+.itemUnit,
+.itemMarket {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.itemKind {
+  margin-bottom: 8px;
+}
+
+.itemPrice {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+}
+
+.itemMarket {
+  margin-top: 6px;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.table th {
+  background: #f7fafc;
+  padding: 10px 14px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.table tr:hover td {
+  background: #f7fafc;
+}
+
+.priceValue {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.rankBadge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.rankGood {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.rankMid {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.rankLow {
+  background: #fce4ec;
+  color: #c62828;
+}
+
+.rankDefault {
+  background: #eceff1;
+  color: #546e7a;
+}
+
+.alertError {
+  background: #ffebee;
+  border: 1px solid #ef9a9a;
+  color: var(--red);
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-size: 13px;
+}
+
+.loadingState,
+.emptyState {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.emptyState small {
+  display: block;
+  margin-top: 6px;
+}
+
+@media (max-width: 980px) {
+  .monthlyForm,
+  .gridTwo,
+  .batchSummary {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 800px) {
+  .hero h2 {
+    font-size: 22px;
   }
 
-  .content {
-    padding-inline: 16px;
+  .header {
+    padding: 0 16px;
   }
 
-  .panel {
-    padding: 20px;
+  .main {
+    padding: 20px 16px 40px;
+  }
+
+  .searchBar {
+    flex-direction: column;
+  }
+
+  .chartWrap {
+    grid-template-columns: repeat(auto-fit, minmax(56px, 1fr));
   }
 }

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -243,7 +243,7 @@ a {
 }
 
 .cardHead {
-  padding: 16px 20px 12px;
+  padding: 14px 16px 10px;
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
@@ -253,17 +253,17 @@ a {
 
 .cardHead h3 {
   margin: 0;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
 }
 
 .meta {
-  font-size: 11px;
+  font-size: 10px;
   color: var(--text-muted);
 }
 
 .cardBody {
-  padding: 20px;
+  padding: 16px;
 }
 
 .tableCardBody {
@@ -450,50 +450,140 @@ a {
 }
 
 .chartWrap {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(68px, 1fr));
-  gap: 12px;
-  min-height: 300px;
-  align-items: end;
-}
-
-.chartItem {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  align-items: center;
-  justify-content: end;
-  min-height: 300px;
+  gap: 14px;
 }
 
-.chartValue {
-  font-size: 11px;
+.lineChartSvg {
+  width: 100%;
+  height: auto;
+  min-height: 180px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fcfefe 0%, #f3f7fb 100%);
+  border: 1px solid var(--border);
+}
+
+.clickablePoint {
+  cursor: pointer;
+}
+
+.lineAxis {
+  stroke: #dbe5ef;
+  stroke-width: 2;
+}
+
+.lineArea {
+  fill: rgba(46, 125, 50, 0.08);
+}
+
+.linePath {
+  fill: none;
+  stroke: url(#price-line-gradient);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.linePoint {
+  stroke: white;
+  stroke-width: 3;
+}
+
+.lineValue {
+  font-size: 10px;
   font-weight: 700;
-  color: var(--accent);
+  text-anchor: middle;
 }
 
-.chartTrack {
-  width: 100%;
-  max-width: 56px;
-  height: 220px;
-  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
-  border-radius: 10px;
+.lineLabel {
+  font-size: 9px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.lineLegend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 6px;
+}
+
+.lineLegendItem {
   display: flex;
-  align-items: end;
-  justify-content: center;
-  overflow: hidden;
-}
-
-.chartBar {
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: linear-gradient(180deg, #ffffff 0%, var(--surface2) 100%);
   width: 100%;
-  border-radius: 10px 10px 0 0;
+  text-align: left;
+  cursor: pointer;
 }
 
-.chartLabel {
-  font-size: 11px;
-  text-align: center;
+.lineLegendItem strong {
+  display: block;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.lineLegendItem p {
+  margin: 1px 0 0;
+  font-size: 10px;
   color: var(--text-muted);
-  word-break: keep-all;
+}
+
+.lineLegendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
+}
+
+.monthlyTrendPath {
+  fill: none;
+  stroke: url(#monthly-trend-gradient);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.monthlyTrendPoint {
+  fill: #42a5f5;
+  stroke: white;
+  stroke-width: 3;
+}
+
+.monthlyTrendLabel {
+  fill: var(--text-muted);
+  font-size: 9px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.monthlyTrendLegend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 6px;
+}
+
+.monthlyTrendLegendItem {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 8px;
+  background: linear-gradient(180deg, #ffffff 0%, var(--surface2) 100%);
+}
+
+.monthlyTrendLegendItem strong {
+  display: block;
+  font-size: 10px;
+}
+
+.monthlyTrendLegendItem p {
+  margin: 2px 0 0;
+  font-size: 10px;
+  color: var(--text-muted);
 }
 
 .priceGrid {
@@ -507,6 +597,8 @@ a {
   border-radius: 10px;
   padding: 14px;
   border: 1px solid var(--border);
+  text-align: left;
+  cursor: pointer;
 }
 
 .itemName {
@@ -653,6 +745,6 @@ a {
   }
 
   .chartWrap {
-    grid-template-columns: repeat(auto-fit, minmax(56px, 1fr));
+    gap: 10px;
   }
 }

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -12,7 +12,7 @@
   --red: #c62828;
   --radius: 12px;
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  font-family: 'Pretendard', 'Segoe UI', system-ui, sans-serif;
+  font-family: Pretendard, "Segoe UI", system-ui, sans-serif;
   color: var(--text);
   background: var(--bg);
   line-height: 1.6;
@@ -138,6 +138,19 @@ a {
   font-size: 14px;
   outline: none;
   color: var(--text);
+}
+
+.searchBar input:focus-visible,
+.filterRow input:focus-visible,
+.field input:focus-visible,
+.field select:focus-visible,
+button:focus-visible,
+a:focus-visible,
+.categoryTab:focus-visible,
+.lineLegendItem:focus-visible,
+.priceCard:focus-visible {
+  outline: 2px solid var(--accent2);
+  outline-offset: 2px;
 }
 
 .searchBar button {

--- a/front/src/vite-env.d.ts
+++ b/front/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/front/tsconfig.app.json
+++ b/front/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/front/tsconfig.node.json
+++ b/front/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+  },
+});

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
   },
 });

--- a/infra/feign/src/main/java/com/source/ApiPriceSource.java
+++ b/infra/feign/src/main/java/com/source/ApiPriceSource.java
@@ -2,24 +2,32 @@ package com.source;
 
 import com.client.MarketPriceClient;
 import com.dto.MarketPriceDailyResponse;
+import com.dto.MarketPriceMonthlyResponse;
 import com.properties.MarketPriceApiProperties;
 import constant.Constants;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import model.price.MonthlyPriceReader;
 import model.price.PriceReadItem;
 import model.price.PriceReader;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ApiPriceSource implements PriceReader {
+public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
 
   private static final String DEFAULT_PERIOD = "3";
   private static final String DEFAULT_ITEM_CODE = "111";
   private static final String DEFAULT_KIND_CODE = "05";
   private static final String DEFAULT_GRADE_RANK = "2";
   private static final String DEFAULT_COUNTY_CODE = "1101";
+  private static final DateTimeFormatter KAMIS_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
   private final MarketPriceClient marketPriceClient;
   private final MarketPriceApiProperties marketPriceApiProperties;
@@ -62,6 +70,27 @@ public class ApiPriceSource implements PriceReader {
         .toList();
   }
 
+  @Override
+  public List<PriceReadItem> readInMonth(String itemCategoryCode, YearMonth yearMonth) {
+    MarketPriceMonthlyResponse response = marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        marketPriceApiProperties.getCertKey(),
+        marketPriceApiProperties.getCertId(),
+        String.valueOf(yearMonth.getYear()),
+        "%02d".formatted(yearMonth.getMonthValue()),
+        itemCategoryCode
+    );
+
+    if (response == null || response.data() == null || response.data().item() == null) {
+      return List.of();
+    }
+
+    return response.data().item().stream()
+        .flatMap(item -> toMonthlyReadItems(item, yearMonth).stream())
+        .toList();
+  }
+
   private int parsePrice(String price) {
     if (price == null) {
       return 0;
@@ -71,5 +100,49 @@ public class ApiPriceSource implements PriceReader {
       return 0;
     }
     return Integer.parseInt(normalized);
+  }
+
+  private List<PriceReadItem> toMonthlyReadItems(
+      MarketPriceMonthlyResponse.MarketPriceMonthlyItem item,
+      YearMonth targetYearMonth
+  ) {
+    List<PriceReadItem> items = new ArrayList<>();
+    Stream.of(
+            monthlyEntry(item, item.day1(), item.dpr1(), targetYearMonth),
+            monthlyEntry(item, item.day2(), item.dpr2(), targetYearMonth)
+        )
+        .flatMap(Optional::stream)
+        .forEach(items::add);
+    return items;
+  }
+
+  private Optional<PriceReadItem> monthlyEntry(
+      MarketPriceMonthlyResponse.MarketPriceMonthlyItem item,
+      String day,
+      String price,
+      YearMonth targetYearMonth
+  ) {
+    if (day == null || day.isBlank() || price == null || price.isBlank()) {
+      return Optional.empty();
+    }
+
+    LocalDate regDay = LocalDate.parse(day, KAMIS_DATE_FORMATTER);
+    if (!YearMonth.from(regDay).equals(targetYearMonth)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(new PriceReadItem(
+        item.itemCode(),
+        item.itemName(),
+        item.kindCode(),
+        item.kindName(),
+        item.marketCode(),
+        item.marketName(),
+        item.rankCode(),
+        item.rankName(),
+        parsePrice(price),
+        item.unit(),
+        regDay
+    ));
   }
 }

--- a/infra/feign/src/main/java/com/source/ApiPriceSource.java
+++ b/infra/feign/src/main/java/com/source/ApiPriceSource.java
@@ -88,7 +88,7 @@ public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
     }
 
     return response.data().item().stream()
-        .flatMap(item -> toMonthlyReadItems(item, yearMonth).stream())
+        .flatMap(item -> toMonthlyReadItems(item, yearMonth, itemCategoryCode).stream())
         .toList();
   }
 
@@ -105,12 +105,13 @@ public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
 
   private List<PriceReadItem> toMonthlyReadItems(
       MarketPriceMonthlyResponse.MarketPriceMonthlyItem item,
-      YearMonth targetYearMonth
+      YearMonth targetYearMonth,
+      String itemCategoryCode
   ) {
     List<PriceReadItem> items = new ArrayList<>();
     Stream.of(
-            monthlyEntry(item, item.day1(), item.dpr1(), targetYearMonth),
-            monthlyEntry(item, item.day2(), item.dpr2(), targetYearMonth)
+            monthlyEntry(item, item.day1(), item.dpr1(), targetYearMonth, itemCategoryCode),
+            monthlyEntry(item, item.day2(), item.dpr2(), targetYearMonth, itemCategoryCode)
         )
         .flatMap(Optional::stream)
         .forEach(items::add);
@@ -121,7 +122,8 @@ public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
       MarketPriceMonthlyResponse.MarketPriceMonthlyItem item,
       String day,
       String price,
-      YearMonth targetYearMonth
+      YearMonth targetYearMonth,
+      String itemCategoryCode
   ) {
     if (day == null || day.isBlank() || price == null || price.isBlank()) {
       return Optional.empty();
@@ -142,13 +144,25 @@ public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
         item.itemName(),
         item.kindCode(),
         item.kindName(),
-        item.marketCode(),
-        item.marketName(),
+        itemCategoryCode,
+        categoryNameOf(itemCategoryCode),
         item.rankCode(),
         item.rankName(),
         parsePrice(price),
         item.unit(),
         regDay
     ));
+  }
+
+  private String categoryNameOf(String itemCategoryCode) {
+    return switch (itemCategoryCode) {
+      case "100" -> "식량작물";
+      case "200" -> "채소류";
+      case "300" -> "특용작물";
+      case "400" -> "과일류";
+      case "500" -> "축산물";
+      case "600" -> "수산물";
+      default -> Constants.NOT_APPLICABLE;
+    };
   }
 }

--- a/infra/feign/src/main/java/com/source/ApiPriceSource.java
+++ b/infra/feign/src/main/java/com/source/ApiPriceSource.java
@@ -7,6 +7,7 @@ import com.properties.MarketPriceApiProperties;
 import constant.Constants;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -126,7 +127,12 @@ public class ApiPriceSource implements PriceReader, MonthlyPriceReader {
       return Optional.empty();
     }
 
-    LocalDate regDay = LocalDate.parse(day, KAMIS_DATE_FORMATTER);
+    final LocalDate regDay;
+    try {
+      regDay = LocalDate.parse(day, KAMIS_DATE_FORMATTER);
+    } catch (DateTimeParseException exception) {
+      return Optional.empty();
+    }
     if (!YearMonth.from(regDay).equals(targetYearMonth)) {
       return Optional.empty();
     }

--- a/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
+++ b/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
@@ -213,6 +213,47 @@ class ApiPriceSourceTest {
   }
 
   @Test
+  void readInMonthSkipsMalformedDayValuesInsteadOfThrowing() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111", "배추", "01", "일반", "100", "서울", "01", "상품", "10kg",
+                    "-", "12,000", "2024/01/16", "11,500", "01"
+                ),
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "112", "무", "01", "일반", "100", "서울", "01", "상품", "20kg",
+                    "N/A", "8,000", "2024/13/40", "7,500", "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    assertThat(result).singleElement().satisfies(item -> {
+      assertThat(item.regDay()).isEqualTo(LocalDate.of(2024, 1, 16));
+      assertThat(item.marketCode()).isEqualTo("200");
+      assertThat(item.marketName()).isEqualTo("채소류");
+    });
+  }
+
+  @Test
   void readInMonthReturnsEmptyWhenMonthlyDataIsNull() {
     MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
     MarketPriceApiProperties properties = new MarketPriceApiProperties();

--- a/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
+++ b/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.verify;
 
 import com.client.MarketPriceClient;
 import com.dto.MarketPriceDailyResponse;
+import com.dto.MarketPriceMonthlyResponse;
 import com.properties.MarketPriceApiProperties;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import model.price.PriceReadItem;
 import org.junit.jupiter.api.Test;
@@ -86,5 +88,61 @@ class ApiPriceSourceTest {
       assertThat(item.price()).isEqualTo(12000);
       assertThat(item.regDay()).isEqualTo(regDay);
     });
+  }
+
+  @Test
+  void readInMonthUsesMonthlySalesParametersAndMapsAvailableDays() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111",
+                    "배추",
+                    "01",
+                    "일반",
+                    "100",
+                    "서울",
+                    "01",
+                    "상품",
+                    "10kg",
+                    "2024/01/15",
+                    "12,000",
+                    "2024/01/16",
+                    "11,500",
+                    "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    verify(marketPriceClient).fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    );
+    assertThat(result).hasSize(2);
+    assertThat(result).extracting(PriceReadItem::regDay)
+        .containsExactly(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 16));
   }
 }

--- a/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
+++ b/infra/feign/src/test/java/com/source/ApiPriceSourceTest.java
@@ -145,4 +145,112 @@ class ApiPriceSourceTest {
     assertThat(result).extracting(PriceReadItem::regDay)
         .containsExactly(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 16));
   }
+
+  @Test
+  void readInMonthReturnsSingleItemWhenSecondDayPairIsBlank() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111", "배추", "01", "일반", "100", "서울", "01", "상품", "10kg",
+                    "2024/01/15", "12,000", "", "", "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    assertThat(result).singleElement().satisfies(item -> assertThat(item.regDay()).isEqualTo(LocalDate.of(2024, 1, 15)));
+  }
+
+  @Test
+  void readInMonthFiltersOutDaysOutsideRequestedMonth() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+    YearMonth yearMonth = YearMonth.of(2024, 1);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(
+        new MarketPriceMonthlyResponse.MarketPriceMonthlyData(
+            List.of(
+                new MarketPriceMonthlyResponse.MarketPriceMonthlyItem(
+                    "111", "배추", "01", "일반", "100", "서울", "01", "상품", "10kg",
+                    "2024/01/15", "12,000", "2024/02/01", "11,500", "01"
+                )
+            )
+        )
+    ));
+
+    List<PriceReadItem> result = apiPriceSource.readInMonth("200", yearMonth);
+
+    assertThat(result).singleElement().satisfies(item -> assertThat(item.regDay()).isEqualTo(LocalDate.of(2024, 1, 15)));
+  }
+
+  @Test
+  void readInMonthReturnsEmptyWhenMonthlyDataIsNull() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(null));
+
+    assertThat(apiPriceSource.readInMonth("200", YearMonth.of(2024, 1))).isEmpty();
+  }
+
+  @Test
+  void readInMonthReturnsEmptyWhenMonthlyItemsAreNull() {
+    MarketPriceClient marketPriceClient = mock(MarketPriceClient.class);
+    MarketPriceApiProperties properties = new MarketPriceApiProperties();
+    properties.setCertKey("test-key");
+    properties.setCertId("test-id");
+    ApiPriceSource apiPriceSource = new ApiPriceSource(marketPriceClient, properties);
+
+    given(marketPriceClient.fetchMonthlyPricesInternal(
+        "monthlySalesList",
+        "json",
+        "test-key",
+        "test-id",
+        "2024",
+        "01",
+        "200"
+    )).willReturn(new MarketPriceMonthlyResponse(new MarketPriceMonthlyResponse.MarketPriceMonthlyData(null)));
+
+    assertThat(apiPriceSource.readInMonth("200", YearMonth.of(2024, 1))).isEmpty();
+  }
 }


### PR DESCRIPTION
## 요약
- 월별 배치 실행 경로와 `run-monthly` API를 추가했습니다.
- 메인 인덱스 경험을 React 화면으로 옮기고 가격 조회/차트/월별 추이 흐름을 연결했습니다.
- 월별 실행 API의 외부 파라미터를 `year/month` 기준으로 정리했습니다.

## 변경 사항
- 백엔드
  - `kamisMonthlyPriceJob` 및 월별 reader/service 추가
  - `POST /api/batch/run-monthly` 추가
  - 월별 요청/응답 DTO 추가 및 배치 상태 응답 보강
- 프론트
  - React 메인 화면에서 카테고리별 조회, 검색, 차트, 가격 카드, 월별 배치 실행 지원
  - 차트 클릭 기반 월별 추이 조회 추가
  - 카테고리 노출/라벨/가독성 개선
- 정합성
  - 외부 월별 실행 파라미터를 `year/month`로 통일

## 검증
- `front npm run build`
- `./gradlew :apps:dragons_api:test --tests com.dragons.interfaces.api.ApiControllerTest`
- 로컬 API 호출 검증
  - `GET /api/batch/config`
  - `GET /api/batch/status`
  - `GET /api/prices/latest`
  - `GET /api/prices/search`
  - `POST /api/batch/run-monthly`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 월별 배치 실행 API 및 프론트엔드 UI(수동 실행 폼, 실행 이력/개요, 상세 결과) 추가
  * React+TypeScript 프런트엔드 스캐폴드와 개발/빌드 설정, 전역 스타일 및 대시보드 페이지 추가
  * 월별 가격 조회 기능과 월간 리더/읽기 API 도입

* **Bug Fixes / Improvements**
  * 배치 상태 표시 개선(구성 플래그, 인증 가드 및 실행 ID 반영)
  * 입력 검증 및 전역 예외 처리 강화

* **Tests**
  * 월별 배치 실행/리더 관련 단위 테스트 및 API 검증 테스트 추가

* **Documentation**
  * 프런트엔드 스캐폴드 생성 보고서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->