### PR TITLE
배치 예외 처리 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ out/
 logs
 .omx/
 AGENTS.md
+.codex/*
+!.codex/agents/
+!.codex/agents/**
+!.codex/skills/
+!.codex/skills/**
+.codex/skills/.system/**
+!.codex/prompts/
+!.codex/prompts/**

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ out/
 .vscode/
 
 .omx
-.codex
 logs
 .omx/
 AGENTS.md

--- a/apps/batch-core/src/main/java/com/application/MonthlyPriceReadService.java
+++ b/apps/batch-core/src/main/java/com/application/MonthlyPriceReadService.java
@@ -1,5 +1,6 @@
 package com.application;
 
+import com.exception.TransientPriceReadException;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,13 @@ public class MonthlyPriceReadService {
   private final MonthlyPriceReader monthlyPriceReader;
 
   public List<PriceReadItem> readItems(String itemCategoryCode, YearMonth yearMonth) {
-    return monthlyPriceReader.readInMonth(itemCategoryCode, yearMonth);
+    try {
+      return monthlyPriceReader.readInMonth(itemCategoryCode, yearMonth);
+    } catch (RuntimeException exception) {
+      if (TransientPriceReadExceptionMapper.isRetryable(exception)) {
+        throw new TransientPriceReadException("KAMIS 월별 가격 API 호출 중 일시 오류가 발생했습니다.", exception);
+      }
+      throw exception;
+    }
   }
 }

--- a/apps/batch-core/src/main/java/com/application/PriceReadService.java
+++ b/apps/batch-core/src/main/java/com/application/PriceReadService.java
@@ -2,6 +2,7 @@ package com.application;
 
 import java.time.LocalDate;
 import java.util.List;
+import com.exception.TransientPriceReadException;
 import lombok.RequiredArgsConstructor;
 import model.price.PriceReadItem;
 import model.price.PriceReader;
@@ -14,6 +15,13 @@ public class PriceReadService {
   private final PriceReader priceReader;
 
   public List<PriceReadItem> readItems(String itemCategoryCode, LocalDate regDay) {
-    return priceReader.readOn(itemCategoryCode, regDay);
+    try {
+      return priceReader.readOn(itemCategoryCode, regDay);
+    } catch (RuntimeException exception) {
+      if (TransientPriceReadExceptionMapper.isRetryable(exception)) {
+        throw new TransientPriceReadException("KAMIS 일별 가격 API 호출 중 일시 오류가 발생했습니다.", exception);
+      }
+      throw exception;
+    }
   }
 }

--- a/apps/batch-core/src/main/java/com/application/TransientPriceReadExceptionMapper.java
+++ b/apps/batch-core/src/main/java/com/application/TransientPriceReadExceptionMapper.java
@@ -1,0 +1,35 @@
+package com.application;
+
+import java.lang.reflect.Method;
+
+final class TransientPriceReadExceptionMapper {
+
+  private static final String FEIGN_RETRYABLE_EXCEPTION = "feign.RetryableException";
+  private static final String FEIGN_EXCEPTION_PREFIX = "feign.FeignException";
+
+  private TransientPriceReadExceptionMapper() {
+  }
+
+  static boolean isRetryable(Throwable throwable) {
+    String className = throwable.getClass().getName();
+    if (FEIGN_RETRYABLE_EXCEPTION.equals(className)) {
+      return true;
+    }
+    if (!className.startsWith(FEIGN_EXCEPTION_PREFIX)) {
+      return false;
+    }
+
+    Integer status = readStatus(throwable);
+    return status != null && (status == 429 || status >= 500);
+  }
+
+  private static Integer readStatus(Throwable throwable) {
+    try {
+      Method statusMethod = throwable.getClass().getMethod("status");
+      Object status = statusMethod.invoke(throwable);
+      return status instanceof Integer value ? value : null;
+    } catch (ReflectiveOperationException exception) {
+      return null;
+    }
+  }
+}

--- a/apps/batch-core/src/main/java/com/application/TransientPriceReadExceptionMapper.java
+++ b/apps/batch-core/src/main/java/com/application/TransientPriceReadExceptionMapper.java
@@ -20,7 +20,7 @@ final class TransientPriceReadExceptionMapper {
     }
 
     Integer status = readStatus(throwable);
-    return status != null && (status == 429 || status >= 500);
+    return status != null && (status == 408 || status == 429 || status >= 500);
   }
 
   private static Integer readStatus(Throwable throwable) {

--- a/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
+++ b/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
@@ -13,6 +13,7 @@ import java.time.YearMonth;
 import model.price.PriceData;
 import model.price.PriceDataRepository;
 import model.price.PriceReadItem;
+import com.exception.TransientPriceReadException;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.listener.ItemWriteListener;
@@ -109,6 +110,8 @@ public class BatchCoreConfiguration {
         .<PriceReadItem, PriceData>chunk(Constants.CHUNK_SIZE)
         .transactionManager(transactionManager)
         .faultTolerant()
+        .retry(TransientPriceReadException.class)
+        .retryLimit(Constants.RETRY_LIMIT)
         .skipPolicy(batchSkipPolicy)
         .reader(kamisItemReader)
         .processor(kamisItemProcessor)
@@ -140,6 +143,8 @@ public class BatchCoreConfiguration {
         .<PriceReadItem, PriceData>chunk(Constants.CHUNK_SIZE)
         .transactionManager(transactionManager)
         .faultTolerant()
+        .retry(TransientPriceReadException.class)
+        .retryLimit(Constants.RETRY_LIMIT)
         .skipPolicy(batchSkipPolicy)
         .reader(kamisMonthlyItemReader)
         .processor(kamisItemProcessor)

--- a/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
+++ b/apps/batch-core/src/main/java/com/config/BatchCoreConfiguration.java
@@ -6,6 +6,7 @@ import com.process.KamisItemProcessor;
 import com.read.KamisItemReader;
 import com.read.KamisMonthlyItemReader;
 import com.write.KamisItemWriter;
+import constant.Constants;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -14,9 +15,13 @@ import model.price.PriceDataRepository;
 import model.price.PriceReadItem;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.listener.ItemWriteListener;
+import org.springframework.batch.core.listener.SkipListener;
+import org.springframework.batch.core.listener.StepExecutionListener;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.skip.SkipPolicy;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.ItemReader;
@@ -30,7 +35,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Configuration(proxyBeanMethods = false)
 public class BatchCoreConfiguration {
 
-  private static final int CHUNK_SIZE = 100;
+
 
   @Bean
   Clock batchClock() {
@@ -56,12 +61,12 @@ public class BatchCoreConfiguration {
   ItemReader<PriceReadItem> kamisMonthlyItemReader(
       MonthlyPriceReadService monthlyPriceReadService,
       @Value("#{jobParameters['itemCategoryCode']}") String itemCategoryCode,
-      @Value("#{jobParameters['yyyy']}") String yyyy,
-      @Value("#{jobParameters['mm']}") String mm
+      @Value("#{jobParameters['yyyy']}") String year,
+      @Value("#{jobParameters['mm']}") String month
   ) {
-    YearMonth yearMonth = (yyyy == null || yyyy.isBlank() || mm == null || mm.isBlank())
+    YearMonth yearMonth = (year == null || year.isBlank() || month == null || month.isBlank())
         ? YearMonth.now()
-        : YearMonth.of(Integer.parseInt(yyyy), Integer.parseInt(mm));
+        : YearMonth.of(Integer.parseInt(year), Integer.parseInt(month));
 
     return new KamisMonthlyItemReader(
         monthlyPriceReadService,
@@ -81,19 +86,36 @@ public class BatchCoreConfiguration {
   }
 
   @Bean
+  SkipPolicy batchSkipPolicy() {
+    return new BatchSkipPolicy(Constants.SKIP_LIMIT);
+  }
+
+  @Bean
+  BatchStepMonitoringListener batchStepMonitoringListener() {
+    return new BatchStepMonitoringListener();
+  }
+
+  @Bean
   Step kamisPriceStep(
       JobRepository jobRepository,
       PlatformTransactionManager transactionManager,
       @Qualifier("kamisItemReader") ItemReader<PriceReadItem> kamisItemReader,
       ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor,
-      ItemWriter<PriceData> kamisItemWriter
+      ItemWriter<PriceData> kamisItemWriter,
+      SkipPolicy batchSkipPolicy,
+      BatchStepMonitoringListener batchStepMonitoringListener
   ) {
     return new StepBuilder("kamisPriceStep", jobRepository)
-        .<PriceReadItem, PriceData>chunk(CHUNK_SIZE)
+        .<PriceReadItem, PriceData>chunk(Constants.CHUNK_SIZE)
         .transactionManager(transactionManager)
+        .faultTolerant()
+        .skipPolicy(batchSkipPolicy)
         .reader(kamisItemReader)
         .processor(kamisItemProcessor)
         .writer(kamisItemWriter)
+        .listener((ItemWriteListener<PriceData>) batchStepMonitoringListener)
+        .listener((SkipListener<PriceReadItem, PriceData>) batchStepMonitoringListener)
+        .listener(batchStepMonitoringListener)
         .build();
   }
 
@@ -110,14 +132,21 @@ public class BatchCoreConfiguration {
       PlatformTransactionManager transactionManager,
       @Qualifier("kamisMonthlyItemReader") ItemReader<PriceReadItem> kamisMonthlyItemReader,
       ItemProcessor<PriceReadItem, PriceData> kamisItemProcessor,
-      ItemWriter<PriceData> kamisItemWriter
+      ItemWriter<PriceData> kamisItemWriter,
+      SkipPolicy batchSkipPolicy,
+      BatchStepMonitoringListener batchStepMonitoringListener
   ) {
     return new StepBuilder("kamisMonthlyPriceStep", jobRepository)
-        .<PriceReadItem, PriceData>chunk(CHUNK_SIZE)
+        .<PriceReadItem, PriceData>chunk(Constants.CHUNK_SIZE)
         .transactionManager(transactionManager)
+        .faultTolerant()
+        .skipPolicy(batchSkipPolicy)
         .reader(kamisMonthlyItemReader)
         .processor(kamisItemProcessor)
         .writer(kamisItemWriter)
+        .listener((ItemWriteListener<PriceData>) batchStepMonitoringListener)
+        .listener((SkipListener<PriceReadItem, PriceData>) batchStepMonitoringListener)
+        .listener(batchStepMonitoringListener)
         .build();
   }
 

--- a/apps/batch-core/src/main/java/com/config/BatchSkipPolicy.java
+++ b/apps/batch-core/src/main/java/com/config/BatchSkipPolicy.java
@@ -1,0 +1,27 @@
+package com.config;
+
+import com.process.SkippablePriceDataException;
+import org.springframework.batch.core.step.skip.SkipLimitExceededException;
+import org.springframework.batch.core.step.skip.SkipPolicy;
+
+public class BatchSkipPolicy implements SkipPolicy {
+
+  private final long skipLimit;
+
+  public BatchSkipPolicy(long skipLimit) {
+    this.skipLimit = skipLimit;
+  }
+
+  @Override
+  public boolean shouldSkip(Throwable throwable, long skipCount) {
+    if (!(throwable instanceof SkippablePriceDataException)) {
+      return false;
+    }
+
+    if (skipCount >= skipLimit) {
+      throw new SkipLimitExceededException(skipLimit, throwable);
+    }
+
+    return true;
+  }
+}

--- a/apps/batch-core/src/main/java/com/config/BatchSkipPolicy.java
+++ b/apps/batch-core/src/main/java/com/config/BatchSkipPolicy.java
@@ -1,6 +1,6 @@
 package com.config;
 
-import com.process.SkippablePriceDataException;
+import com.exception.SkippablePriceDataException;
 import org.springframework.batch.core.step.skip.SkipLimitExceededException;
 import org.springframework.batch.core.step.skip.SkipPolicy;
 

--- a/apps/batch-core/src/main/java/com/config/BatchStepMonitoringListener.java
+++ b/apps/batch-core/src/main/java/com/config/BatchStepMonitoringListener.java
@@ -1,0 +1,93 @@
+package com.config;
+
+import lombok.extern.slf4j.Slf4j;
+import model.price.PriceData;
+import model.price.PriceReadItem;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.listener.ItemWriteListener;
+import org.springframework.batch.core.listener.SkipListener;
+import org.springframework.batch.core.listener.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.step.skip.SkipLimitExceededException;
+import org.springframework.batch.infrastructure.item.Chunk;
+
+@Slf4j
+public class BatchStepMonitoringListener
+    implements ItemWriteListener<PriceData>, SkipListener<PriceReadItem, PriceData>, StepExecutionListener {
+
+  @Override
+  public void beforeWrite(Chunk<? extends PriceData> items) {
+    log.debug("About to write {} price items.", items.size());
+  }
+
+  @Override
+  public void afterWrite(Chunk<? extends PriceData> items) {
+    log.info("Successfully wrote {} price items.", items.size());
+  }
+
+  @Override
+  public void onWriteError(Exception exception, Chunk<? extends PriceData> items) {
+    log.error("Write failed for {} price items.", items.size(), exception);
+  }
+
+  @Override
+  public void onSkipInProcess(PriceReadItem item, Throwable throwable) {
+    log.warn(
+        "Skipped invalid price item during process. itemCode={}, itemName={}, regDay={}, reason={}",
+        item == null ? null : item.itemCode(),
+        item == null ? null : item.itemName(),
+        item == null ? null : item.regDay(),
+        throwable.getMessage()
+    );
+  }
+
+  @Override
+  public void onSkipInWrite(PriceData item, Throwable throwable) {
+    log.warn(
+        "Skipped price data during write. itemCode={}, itemName={}, regDay={}, reason={}",
+        item == null ? null : item.getItemCode(),
+        item == null ? null : item.getItemName(),
+        item == null ? null : item.getRegDay(),
+        throwable.getMessage()
+    );
+  }
+
+  @Override
+  public ExitStatus afterStep(StepExecution stepExecution) {
+    long totalSkipCount =
+        stepExecution.getReadSkipCount() + stepExecution.getProcessSkipCount() + stepExecution.getWriteSkipCount();
+
+    if (totalSkipCount > 0) {
+      log.warn(
+          "Step completed with skipped items. stepName={}, status={}, readSkip={}, processSkip={}, writeSkip={}, totalSkip={}",
+          stepExecution.getStepName(),
+          stepExecution.getStatus(),
+          stepExecution.getReadSkipCount(),
+          stepExecution.getProcessSkipCount(),
+          stepExecution.getWriteSkipCount(),
+          totalSkipCount
+      );
+    } else {
+      log.info(
+          "Step completed without skips. stepName={}, status={}, readCount={}, writeCount={}",
+          stepExecution.getStepName(),
+          stepExecution.getStatus(),
+          stepExecution.getReadCount(),
+          stepExecution.getWriteCount()
+      );
+    }
+
+    boolean skipLimitExceeded = stepExecution.getFailureExceptions().stream()
+        .anyMatch(exception -> exception instanceof SkipLimitExceededException);
+    if (skipLimitExceeded) {
+      log.error(
+          "Skip limit exceeded. stepName={}, skipCount={}, failureCount={}",
+          stepExecution.getStepName(),
+          totalSkipCount,
+          stepExecution.getFailureExceptions().size()
+      );
+    }
+
+    return null;
+  }
+}

--- a/apps/batch-core/src/main/java/com/config/BatchStepMonitoringListener.java
+++ b/apps/batch-core/src/main/java/com/config/BatchStepMonitoringListener.java
@@ -22,7 +22,7 @@ public class BatchStepMonitoringListener
 
   @Override
   public void afterWrite(Chunk<? extends PriceData> items) {
-    log.info("Successfully wrote {} price items.", items.size());
+    log.debug("Successfully wrote {} price items.", items.size());
   }
 
   @Override

--- a/apps/batch-core/src/main/java/com/exception/SkippablePriceDataException.java
+++ b/apps/batch-core/src/main/java/com/exception/SkippablePriceDataException.java
@@ -1,4 +1,4 @@
-package com.process;
+package com.exception;
 
 public class SkippablePriceDataException extends RuntimeException {
 

--- a/apps/batch-core/src/main/java/com/exception/TransientPriceReadException.java
+++ b/apps/batch-core/src/main/java/com/exception/TransientPriceReadException.java
@@ -1,0 +1,8 @@
+package com.exception;
+
+public class TransientPriceReadException extends RuntimeException {
+
+  public TransientPriceReadException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/apps/batch-core/src/main/java/com/process/KamisItemProcessor.java
+++ b/apps/batch-core/src/main/java/com/process/KamisItemProcessor.java
@@ -18,6 +18,22 @@ public class KamisItemProcessor implements ItemProcessor<PriceReadItem, PriceDat
       return null;
     }
 
+    if (item.itemCode() == null || item.itemCode().isBlank()) {
+      throw new SkippablePriceDataException("itemCode가 비어 있습니다.");
+    }
+    if (item.itemName() == null || item.itemName().isBlank()) {
+      throw new SkippablePriceDataException("itemName이 비어 있습니다.");
+    }
+    if (item.unit() == null || item.unit().isBlank()) {
+      throw new SkippablePriceDataException("unit이 비어 있습니다.");
+    }
+    if (item.regDay() == null) {
+      throw new SkippablePriceDataException("regDay가 비어 있습니다.");
+    }
+    if (item.price() <= 0) {
+      throw new SkippablePriceDataException("price가 0 이하입니다.");
+    }
+
     return PriceData.create(
         item.itemCode(),
         item.itemName(),

--- a/apps/batch-core/src/main/java/com/process/KamisItemProcessor.java
+++ b/apps/batch-core/src/main/java/com/process/KamisItemProcessor.java
@@ -1,5 +1,6 @@
 package com.process;
 
+import com.exception.SkippablePriceDataException;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;

--- a/apps/batch-core/src/main/java/com/process/SkippablePriceDataException.java
+++ b/apps/batch-core/src/main/java/com/process/SkippablePriceDataException.java
@@ -1,0 +1,8 @@
+package com.process;
+
+public class SkippablePriceDataException extends RuntimeException {
+
+  public SkippablePriceDataException(String message) {
+    super(message);
+  }
+}

--- a/apps/batch-core/src/test/java/com/application/read/PriceReadServiceTest.java
+++ b/apps/batch-core/src/test/java/com/application/read/PriceReadServiceTest.java
@@ -1,9 +1,13 @@
 package com.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import com.exception.TransientPriceReadException;
+import feign.FeignException;
+import feign.RetryableException;
 import java.time.LocalDate;
 import java.util.List;
 import model.price.PriceReadItem;
@@ -24,5 +28,39 @@ class PriceReadServiceTest {
     given(priceReader.readOn("200", regDay)).willReturn(expected);
 
     assertThat(priceReadService.readItems("200", regDay)).isEqualTo(expected);
+  }
+
+  @Test
+  void readItemsConvertsRequestTimeoutFeignExceptionToTransientException() {
+    PriceReadService priceReadService = new PriceReadService(failingReader(new FeignException(408)));
+
+    assertThatThrownBy(() -> priceReadService.readItems("100", LocalDate.of(2024, 1, 15)))
+        .isInstanceOf(TransientPriceReadException.class)
+        .hasMessage("KAMIS 일별 가격 API 호출 중 일시 오류가 발생했습니다.")
+        .hasCauseInstanceOf(FeignException.class);
+  }
+
+  @Test
+  void readItemsConvertsRetryableFeignExceptionToTransientException() {
+    PriceReadService priceReadService = new PriceReadService(failingReader(new RetryableException()));
+
+    assertThatThrownBy(() -> priceReadService.readItems("100", LocalDate.of(2024, 1, 15)))
+        .isInstanceOf(TransientPriceReadException.class)
+        .hasMessage("KAMIS 일별 가격 API 호출 중 일시 오류가 발생했습니다.")
+        .hasCauseInstanceOf(RetryableException.class);
+  }
+
+  @Test
+  void readItemsRethrowsNonTransientFeignException() {
+    PriceReadService priceReadService = new PriceReadService(failingReader(new FeignException(400)));
+
+    assertThatThrownBy(() -> priceReadService.readItems("100", LocalDate.of(2024, 1, 15)))
+        .isInstanceOf(FeignException.class);
+  }
+
+  private PriceReader failingReader(RuntimeException exception) {
+    return (itemCategoryCode, regDay) -> {
+      throw exception;
+    };
   }
 }

--- a/apps/batch-core/src/test/java/com/config/BatchSkipPolicyTest.java
+++ b/apps/batch-core/src/test/java/com/config/BatchSkipPolicyTest.java
@@ -3,7 +3,7 @@ package com.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.process.SkippablePriceDataException;
+import com.exception.SkippablePriceDataException;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.step.skip.SkipLimitExceededException;
 

--- a/apps/batch-core/src/test/java/com/config/BatchSkipPolicyTest.java
+++ b/apps/batch-core/src/test/java/com/config/BatchSkipPolicyTest.java
@@ -1,0 +1,34 @@
+package com.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.process.SkippablePriceDataException;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.step.skip.SkipLimitExceededException;
+
+class BatchSkipPolicyTest {
+
+  @Test
+  void shouldSkipReturnsTrueForSkippableExceptionUnderLimit() {
+    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(10);
+
+    assertThat(batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), 0)).isTrue();
+    assertThat(batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), 9)).isTrue();
+  }
+
+  @Test
+  void shouldSkipThrowsWhenSkippableExceptionExceedsLimit() {
+    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(10);
+
+    assertThatThrownBy(() -> batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), 10))
+        .isInstanceOf(SkipLimitExceededException.class);
+  }
+
+  @Test
+  void shouldSkipReturnsFalseForNonSkippableException() {
+    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(10);
+
+    assertThat(batchSkipPolicy.shouldSkip(new IllegalStateException("db down"), 0)).isFalse();
+  }
+}

--- a/apps/batch-core/src/test/java/com/config/BatchSkipPolicyTest.java
+++ b/apps/batch-core/src/test/java/com/config/BatchSkipPolicyTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.exception.SkippablePriceDataException;
+import constant.Constants;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.step.skip.SkipLimitExceededException;
 
@@ -11,23 +12,23 @@ class BatchSkipPolicyTest {
 
   @Test
   void shouldSkipReturnsTrueForSkippableExceptionUnderLimit() {
-    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(10);
+    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(Constants.SKIP_LIMIT);
 
     assertThat(batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), 0)).isTrue();
-    assertThat(batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), 9)).isTrue();
+    assertThat(batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), Constants.SKIP_LIMIT - 1)).isTrue();
   }
 
   @Test
   void shouldSkipThrowsWhenSkippableExceptionExceedsLimit() {
-    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(10);
+    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(Constants.SKIP_LIMIT);
 
-    assertThatThrownBy(() -> batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), 10))
+    assertThatThrownBy(() -> batchSkipPolicy.shouldSkip(new SkippablePriceDataException("bad row"), Constants.SKIP_LIMIT))
         .isInstanceOf(SkipLimitExceededException.class);
   }
 
   @Test
   void shouldSkipReturnsFalseForNonSkippableException() {
-    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(10);
+    BatchSkipPolicy batchSkipPolicy = new BatchSkipPolicy(Constants.SKIP_LIMIT);
 
     assertThat(batchSkipPolicy.shouldSkip(new IllegalStateException("db down"), 0)).isFalse();
   }

--- a/apps/batch-core/src/test/java/com/process/KamisItemProcessorTest.java
+++ b/apps/batch-core/src/test/java/com/process/KamisItemProcessorTest.java
@@ -1,5 +1,6 @@
 package com.process;
 
+import com.exception.SkippablePriceDataException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/apps/batch-core/src/test/java/com/process/KamisItemProcessorTest.java
+++ b/apps/batch-core/src/test/java/com/process/KamisItemProcessorTest.java
@@ -1,6 +1,7 @@
 package com.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -53,5 +54,27 @@ class KamisItemProcessorTest {
     KamisItemProcessor processor = new KamisItemProcessor(Clock.systemDefaultZone());
 
     assertThat(processor.process(null)).isNull();
+  }
+
+  @Test
+  void processThrowsSkippableExceptionWhenPriceIsZeroOrNegative() {
+    KamisItemProcessor processor = new KamisItemProcessor(Clock.systemDefaultZone());
+    PriceReadItem item = new PriceReadItem(
+        "111",
+        "배추",
+        "01",
+        "일반",
+        "100",
+        "서울",
+        "01",
+        "상품",
+        0,
+        "10kg",
+        LocalDate.of(2024, 1, 15)
+    );
+
+    assertThatThrownBy(() -> processor.process(item))
+        .isInstanceOf(SkippablePriceDataException.class)
+        .hasMessage("price가 0 이하입니다.");
   }
 }

--- a/apps/batch-core/src/test/java/com/process/KamisItemProcessorTest.java
+++ b/apps/batch-core/src/test/java/com/process/KamisItemProcessorTest.java
@@ -60,7 +60,7 @@ class KamisItemProcessorTest {
   @Test
   void processThrowsSkippableExceptionWhenPriceIsZeroOrNegative() {
     KamisItemProcessor processor = new KamisItemProcessor(Clock.systemDefaultZone());
-    PriceReadItem item = new PriceReadItem(
+    PriceReadItem zeroPriceItem = new PriceReadItem(
         "111",
         "배추",
         "01",
@@ -73,8 +73,24 @@ class KamisItemProcessorTest {
         "10kg",
         LocalDate.of(2024, 1, 15)
     );
+    PriceReadItem negativePriceItem = new PriceReadItem(
+        "111",
+        "배추",
+        "01",
+        "일반",
+        "100",
+        "서울",
+        "01",
+        "상품",
+        -1,
+        "10kg",
+        LocalDate.of(2024, 1, 15)
+    );
 
-    assertThatThrownBy(() -> processor.process(item))
+    assertThatThrownBy(() -> processor.process(zeroPriceItem))
+        .isInstanceOf(SkippablePriceDataException.class)
+        .hasMessage("price가 0 이하입니다.");
+    assertThatThrownBy(() -> processor.process(negativePriceItem))
         .isInstanceOf(SkippablePriceDataException.class)
         .hasMessage("price가 0 이하입니다.");
   }

--- a/apps/batch-core/src/test/java/feign/FeignException.java
+++ b/apps/batch-core/src/test/java/feign/FeignException.java
@@ -1,0 +1,15 @@
+package feign;
+
+public class FeignException extends RuntimeException {
+
+  private final int status;
+
+  public FeignException(int status) {
+    super("Feign status: " + status);
+    this.status = status;
+  }
+
+  public int status() {
+    return status;
+  }
+}

--- a/apps/batch-core/src/test/java/feign/RetryableException.java
+++ b/apps/batch-core/src/test/java/feign/RetryableException.java
@@ -1,0 +1,8 @@
+package feign;
+
+public class RetryableException extends RuntimeException {
+
+  public RetryableException() {
+    super("retryable");
+  }
+}

--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -185,6 +185,30 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   }
 
   @Test
+  void runBatchSkipsInvalidItemsAndStillCompletes() throws Exception {
+    LocalDate regDay = LocalDate.of(2024, 1, 15);
+    given(priceReadService.readItems("200", regDay))
+        .willReturn(
+            List.of(
+                new PriceReadItem("911", "정상 배추", "01", "일반", "100", "서울", "01", "상품", 12345, "10kg", regDay),
+                new PriceReadItem("912", "비정상 무", "01", "일반", "100", "서울", "01", "상품", 0, "20kg", regDay)
+            )
+        );
+
+    HttpResponse<String> response = sendPost("/api/batch/run?itemCategoryCode=200&regDay=2024-01-15");
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
+    assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("정상"))
+        .extracting(PriceData::getItemCode)
+        .containsExactly("911");
+    assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("비정상"))
+        .isEmpty();
+    assertThat(jdbcTemplate.queryForObject("select sum(PROCESS_SKIP_COUNT) from BATCH_STEP_EXECUTION", Integer.class))
+        .isEqualTo(1);
+  }
+
+  @Test
   void runBatchPersistsExecutionMetadataInDatabase() throws Exception {
     LocalDate regDay = LocalDate.of(2024, 1, 15);
     given(priceReadService.readItems("200", regDay))

--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -2,6 +2,8 @@ package com.dragons.interfaces.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.application.MonthlyPriceReadService;
 import com.application.PriceReadService;
@@ -20,6 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import model.price.PriceData;
 import model.price.PriceReadItem;
+import com.exception.TransientPriceReadException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -206,6 +209,27 @@ class ApiControllerTest extends MySqlContainerTestSupport {
         .isEmpty();
     assertThat(jdbcTemplate.queryForObject("select sum(PROCESS_SKIP_COUNT) from BATCH_STEP_EXECUTION", Integer.class))
         .isEqualTo(1);
+  }
+
+  @Test
+  void runBatchRetriesTransientReadFailureAndCompletes() throws Exception {
+    LocalDate regDay = LocalDate.of(2024, 1, 15);
+    given(priceReadService.readItems("200", regDay))
+        .willThrow(new TransientPriceReadException("temporary timeout", new RuntimeException("timeout")))
+        .willReturn(
+            List.of(
+                new PriceReadItem("911", "재시도 배추", "01", "일반", "100", "서울", "01", "상품", 12345, "10kg", regDay)
+            )
+        );
+
+    HttpResponse<String> response = sendPost("/api/batch/run?itemCategoryCode=200&regDay=2024-01-15");
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).contains("\"status\":\"COMPLETED\"");
+    assertThat(jpaPriceDataRepository.findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc("재시도"))
+        .extracting(PriceData::getItemCode)
+        .containsExactly("911");
+    verify(priceReadService, times(2)).readItems("200", regDay);
   }
 
   @Test

--- a/common/src/main/java/constant/Constants.java
+++ b/common/src/main/java/constant/Constants.java
@@ -17,6 +17,10 @@ public final class Constants {
   public static final String NOT_APPLICABLE = "";
   public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
+
+  public static final int CHUNK_SIZE = 100;
+  public static final int SKIP_LIMIT = 10;
+
   private Constants() {
   }
 }

--- a/common/src/main/java/constant/Constants.java
+++ b/common/src/main/java/constant/Constants.java
@@ -20,6 +20,7 @@ public final class Constants {
 
   public static final int CHUNK_SIZE = 100;
   public static final int SKIP_LIMIT = 10;
+  public static final int RETRY_LIMIT = 3;
 
   private Constants() {
   }


### PR DESCRIPTION
## 요약
- 배치 처리 중 데이터 품질 문제는 skip으로 처리하도록 정책을 추가했습니다.
- 외부 API의 일시적인 읽기 실패는 retry 대상으로 분리했습니다.
- skip/retry 대상이 아닌 예외는 기존처럼 Step/Job 실패로 드러나도록 했습니다.

## 변경 사항
- `SkippablePriceDataException`, `TransientPriceReadException`를 `com.exception` 패키지에 추가
- 일별/월별 배치 Step에 skip policy와 retry limit 적용
- KAMIS 응답 데이터 검증 실패 시 skip 예외 발생
- Feign 계열 일시 장애를 retry 가능한 읽기 예외로 변환
- skip/retry 동작 검증 테스트 추가 및 수정

## 검증
- `./gradlew :apps:batch-core:test --tests com.config.BatchSkipPolicyTest --tests com.process.KamisItemProcessorTest :apps:dragons_api:test --tests com.dragons.interfaces.api.ApiControllerTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 배치 처리 시 일시적 실패 자동 재시도 지원 추가
  * 유효하지 않은 항목 자동 건너뛰기 및 건너뛰기 한도 적용
  * 배치 단계 모니터링과 상세 로깅(처리·건너뛰기·오류 요약) 추가

* **버그 수정**
  * 가격 데이터 입력 유효성 검사 강화 (빈값·음수 등 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->