### PR TITLE
Step 5 가격 추이 시각화를 완성한다

### DIFF
--- a/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
+++ b/apps/dragons_api/src/test/java/com/dragons/interfaces/api/ApiControllerTest.java
@@ -83,11 +83,18 @@ class ApiControllerTest extends MySqlContainerTestSupport {
   }
 
   @Test
-  void getLatestPricesReturnsLimitedResults() throws Exception {
+  void getLatestPricesReturnsLimitedResultsByRegDay() throws Exception {
+    jpaPriceDataRepository.saveAndFlush(
+        priceData("999", "생성일만 최신", "01", "일반", "100", "서울", "01", "상품", 1_000, "1kg", "2024-01-10", "2026-01-01T00:00:00")
+    );
+
     HttpResponse<String> response = sendGet("/api/prices/latest?limit=2");
 
     assertThat(response.statusCode()).isEqualTo(200);
     assertThat(response.body()).contains("\"data\":{\"count\":2");
+    assertThat(response.body()).contains("\"itemName\":\"양파\"");
+    assertThat(response.body()).contains("\"itemName\":\"사과\"");
+    assertThat(response.body()).doesNotContain("생성일만 최신");
   }
 
   @Test

--- a/front/index.html
+++ b/front/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dragons Batch Front</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/front/index.html
+++ b/front/index.html
@@ -4,7 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dragons Batch Front</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+      integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
+      crossorigin="anonymous"
+      defer
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -189,10 +189,12 @@ export default function App() {
 
   const trendCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const trendChartRef = useRef<ChartInstance | null>(null);
+  const trendRequestIdRef = useRef(0);
 
   const batchPageHref = `${getBackendOrigin()}/batch.html`;
 
   function resetTrend() {
+    trendRequestIdRef.current += 1;
     setSelectedTrendItem(null);
     setSelectedTrendSeriesKey('');
     setTrendItems([]);
@@ -208,7 +210,7 @@ export default function App() {
     const grouped = new Map<string, { total: number; count: number; unit: string }>();
 
     priceItems.forEach((item) => {
-      if (!item.price) return;
+      if (item.price == null) return;
 
       const current = grouped.get(item.itemName) ?? { total: 0, count: 0, unit: item.unit };
       current.total += item.price;
@@ -292,7 +294,7 @@ export default function App() {
     const grouped = new Map<string, { total: number; count: number }>();
 
     selectedTrendSeries.items.forEach((item) => {
-      if (!item.price || !item.regDay) return;
+      if (item.price == null || !item.regDay) return;
       const current = grouped.get(item.regDay) ?? { total: 0, count: 0 };
       current.total += item.price;
       current.count += 1;
@@ -386,6 +388,7 @@ export default function App() {
   }, []);
 
   async function loadItemTrend(itemName: string, itemMarketCode?: string) {
+    const requestId = ++trendRequestIdRef.current;
     setSelectedTrendItem(itemName);
     setSelectedTrendSeriesKey('');
     setIsTrendLoading(true);
@@ -393,15 +396,21 @@ export default function App() {
 
     try {
       const response = await searchPrices(itemName);
+      if (requestId !== trendRequestIdRef.current) return;
+
       const exactItems = response.data.filter(
         (item) => item.itemName === itemName && (itemMarketCode == null || item.marketCode === itemMarketCode),
       );
       setTrendItems(exactItems);
     } catch (error) {
+      if (requestId !== trendRequestIdRef.current) return;
+
       setTrendError(error instanceof Error ? error.message : '추이 데이터를 불러오지 못했습니다.');
       setTrendItems([]);
     } finally {
-      setIsTrendLoading(false);
+      if (requestId === trendRequestIdRef.current) {
+        setIsTrendLoading(false);
+      }
     }
   }
 
@@ -424,11 +433,6 @@ export default function App() {
   useEffect(() => {
     const canvas = trendCanvasRef.current;
     const Chart = window.Chart;
-
-    if (trendChartRef.current != null) {
-      trendChartRef.current.destroy();
-      trendChartRef.current = null;
-    }
 
     if (canvas == null || dailyTrend == null || selectedTrendSeries == null) {
       return;

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import {
   fetchBatchConfig,
   fetchBatchStatuses,
@@ -17,6 +17,12 @@ type MonthlyRunForm = {
   itemCategoryCode: string;
   year: string;
   month: string;
+};
+
+type TrendSeriesOption = {
+  key: string;
+  label: string;
+  items: PriceItem[];
 };
 
 function createInitialMonthlyForm(): MonthlyRunForm {
@@ -92,10 +98,6 @@ function getRankTone(rankName: string) {
   if (rankName.includes('중품')) return 'rankMid';
   if (rankName.includes('하품')) return 'rankLow';
   return 'rankDefault';
-}
-
-function toMonthKey(regDay: string) {
-  return regDay.slice(0, 7);
 }
 
 function buildSmoothPath(points: Array<{ x: number; y: number }>) {
@@ -179,11 +181,23 @@ export default function App() {
   const [isMonthlySubmitting, setIsMonthlySubmitting] = useState(false);
   const [isHistoryRefreshing, setIsHistoryRefreshing] = useState(false);
   const [selectedTrendItem, setSelectedTrendItem] = useState<string | null>(null);
+  const [selectedTrendSeriesKey, setSelectedTrendSeriesKey] = useState('');
   const [trendItems, setTrendItems] = useState<PriceItem[]>([]);
   const [isTrendLoading, setIsTrendLoading] = useState(false);
   const [trendError, setTrendError] = useState<string | null>(null);
+  const [isPriceTableExpanded, setIsPriceTableExpanded] = useState(false);
+
+  const trendCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const trendChartRef = useRef<ChartInstance | null>(null);
 
   const batchPageHref = `${getBackendOrigin()}/batch.html`;
+
+  function resetTrend() {
+    setSelectedTrendItem(null);
+    setSelectedTrendSeriesKey('');
+    setTrendItems([]);
+    setTrendError(null);
+  }
 
   const monthlyHistory = useMemo(
     () => batchStatuses.filter((item) => item.jobName === 'kamisMonthlyPriceJob').slice(0, 5),
@@ -239,6 +253,11 @@ export default function App() {
     return { width, height, paddingBottom, points, linePath, areaPath };
   }, [chartData]);
 
+  const visiblePriceItems = useMemo(
+    () => (isPriceTableExpanded ? priceItems : priceItems.slice(0, 5)),
+    [isPriceTableExpanded, priceItems],
+  );
+
   const priceCards = useMemo(() => {
     const seen = new Set<string>();
     return priceItems.filter((item) => {
@@ -248,42 +267,47 @@ export default function App() {
     }).slice(0, 12);
   }, [priceItems]);
 
-  const monthlyTrend = useMemo(() => {
-    const grouped = new Map<string, { total: number; count: number; unit: string }>();
+  const trendSeriesOptions = useMemo<TrendSeriesOption[]>(() => {
+    const grouped = new Map<string, TrendSeriesOption>();
 
     trendItems.forEach((item) => {
-      const key = toMonthKey(item.regDay);
-      const current = grouped.get(key) ?? { total: 0, count: 0, unit: item.unit };
-      current.total += item.price;
-      current.count += 1;
-      if (!current.unit && item.unit) current.unit = item.unit;
+      const key = [item.marketCode, item.kindCode, item.rankCode, item.unit].join('|');
+      const label = [item.marketName, item.kindName, item.rankName, item.unit].filter(Boolean).join(' · ');
+      const current = grouped.get(key) ?? { key, label: label || item.itemName, items: [] };
+      current.items.push(item);
       grouped.set(key, current);
     });
 
-    const rows = [...grouped.entries()]
-      .map(([month, value]) => ({
-        month,
-        value: Math.round(value.total / value.count),
-        unit: value.unit,
-      }))
-      .sort((left, right) => left.month.localeCompare(right.month));
-
-    if (rows.length === 0) {
-      return null;
-    }
-
-    const width = 760;
-    const height = 260;
-    const paddingX = 40;
-    const paddingTop = 20;
-    const paddingBottom = 36;
-    const points = createScaledPoints(rows, width, height, paddingX, paddingTop, paddingBottom);
-    const baselineY = height - paddingBottom;
-    const linePath = buildSmoothPath(points);
-    const areaPath = buildAreaPath(points, baselineY);
-
-    return { width, height, paddingBottom, points, linePath, areaPath };
+    return [...grouped.values()].sort((left, right) => left.label.localeCompare(right.label, 'ko-KR'));
   }, [trendItems]);
+
+  const selectedTrendSeries = useMemo(() => {
+    if (trendSeriesOptions.length === 0) return null;
+    return trendSeriesOptions.find((series) => series.key === selectedTrendSeriesKey) ?? trendSeriesOptions[0];
+  }, [selectedTrendSeriesKey, trendSeriesOptions]);
+
+  const dailyTrend = useMemo(() => {
+    if (selectedTrendSeries == null) return null;
+
+    const grouped = new Map<string, { total: number; count: number }>();
+
+    selectedTrendSeries.items.forEach((item) => {
+      if (!item.price || !item.regDay) return;
+      const current = grouped.get(item.regDay) ?? { total: 0, count: 0 };
+      current.total += item.price;
+      current.count += 1;
+      grouped.set(item.regDay, current);
+    });
+
+    const rows = [...grouped.entries()]
+      .map(([regDay, value]) => ({
+        regDay,
+        value: Math.round(value.total / value.count),
+      }))
+      .sort((left, right) => left.regDay.localeCompare(right.regDay));
+
+    return rows.length === 0 ? null : rows;
+  }, [selectedTrendSeries]);
 
   async function loadPrices(
     task: Promise<{ data: PriceItem[] }>,
@@ -311,7 +335,11 @@ export default function App() {
 
   async function loadLatest(categoryCode = currentCategory) {
     const category = getCategoryMeta(categoryCode);
+    const isCategoryChanged = categoryCode !== currentCategory;
     setCurrentCategory(categoryCode);
+    if (isCategoryChanged) {
+      resetTrend();
+    }
     const nextItems = await loadPrices(fetchLatestPrices(500), category.label, { categoryCode });
     if (nextItems[0]?.regDay) {
       setSelectedDate(nextItems[0].regDay);
@@ -357,15 +385,16 @@ export default function App() {
     void Promise.all([loadLatest(DEFAULT_ITEM_CATEGORY), refreshBatchOverview()]);
   }, []);
 
-  async function loadItemTrend(itemName: string, itemMarketCode: string) {
+  async function loadItemTrend(itemName: string, itemMarketCode?: string) {
     setSelectedTrendItem(itemName);
+    setSelectedTrendSeriesKey('');
     setIsTrendLoading(true);
     setTrendError(null);
 
     try {
       const response = await searchPrices(itemName);
       const exactItems = response.data.filter(
-        (item) => item.itemName === itemName && item.marketCode === itemMarketCode,
+        (item) => item.itemName === itemName && (itemMarketCode == null || item.marketCode === itemMarketCode),
       );
       setTrendItems(exactItems);
     } catch (error) {
@@ -391,6 +420,96 @@ export default function App() {
       setIsMonthlySubmitting(false);
     }
   }
+
+  useEffect(() => {
+    const canvas = trendCanvasRef.current;
+    const Chart = window.Chart;
+
+    if (trendChartRef.current != null) {
+      trendChartRef.current.destroy();
+      trendChartRef.current = null;
+    }
+
+    if (canvas == null || dailyTrend == null || selectedTrendSeries == null) {
+      return;
+    }
+
+    if (Chart == null) {
+      setTrendError('Chart.js를 불러오지 못했습니다.');
+      return;
+    }
+
+    const context = canvas.getContext('2d');
+    if (context == null) {
+      setTrendError('차트를 렌더링할 수 없습니다.');
+      return;
+    }
+
+    trendChartRef.current = new Chart(context, {
+      type: 'line',
+      data: {
+        labels: dailyTrend.map((row) => row.regDay),
+        datasets: [
+          {
+            label: selectedTrendSeries.label,
+            data: dailyTrend.map((row) => row.value),
+            borderColor: '#2e7d32',
+            backgroundColor: 'rgba(46, 125, 50, 0.14)',
+            fill: true,
+            tension: 0.35,
+            pointBackgroundColor: '#42a5f5',
+            pointBorderColor: '#ffffff',
+            pointBorderWidth: 2,
+            pointRadius: 5,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: {
+          intersect: false,
+          mode: 'index',
+        },
+        plugins: {
+          legend: {
+            display: true,
+            position: 'top',
+          },
+          tooltip: {
+            callbacks: {
+              label: (context) => `${context.dataset.label}: ${formatPrice(context.parsed.y)}`,
+            },
+          },
+        },
+        scales: {
+          x: {
+            title: {
+              display: true,
+              text: '날짜',
+            },
+          },
+          y: {
+            beginAtZero: false,
+            title: {
+              display: true,
+              text: '가격',
+            },
+            ticks: {
+              callback: (value) => formatPrice(Number(value)),
+            },
+          },
+        },
+      },
+    });
+
+    return () => {
+      if (trendChartRef.current != null) {
+        trendChartRef.current.destroy();
+        trendChartRef.current = null;
+      }
+    };
+  }, [dailyTrend, selectedTrendSeries]);
 
   function updateMonthlyField<Key extends keyof MonthlyRunForm>(key: Key, value: MonthlyRunForm[Key]) {
     setMonthlyForm((current) => ({
@@ -666,7 +785,7 @@ export default function App() {
                           <g
                             className={styles.clickablePoint}
                             key={point.label}
-                            onClick={() => void loadItemTrend(point.label, currentCategory)}
+                            onClick={() => void loadItemTrend(point.label)}
                           >
                             <circle
                               className={styles.linePoint}
@@ -694,7 +813,7 @@ export default function App() {
                           <button
                             className={styles.lineLegendItem}
                             key={point.label}
-                            onClick={() => void loadItemTrend(point.label, currentCategory)}
+                            onClick={() => void loadItemTrend(point.label)}
                             type="button"
                           >
                             <span className={styles.lineLegendDot} style={{ backgroundColor: point.color }} />
@@ -748,65 +867,44 @@ export default function App() {
 
         <article className={styles.card}>
           <div className={styles.cardHead}>
-            <h3>{selectedTrendItem ? `${selectedTrendItem} 월별 추이` : '품목 월별 추이'}</h3>
+            <h3>{selectedTrendItem ? `${selectedTrendItem} 날짜별 추이` : '품목 날짜별 추이'}</h3>
             <span className={styles.meta}>
               {selectedTrendItem
-                ? trendItems.find((item) => item.unit)?.unit
-                  ? `단위 ${trendItems.find((item) => item.unit)?.unit} · 차트나 카드를 클릭해 불러온 결과`
-                  : '차트나 카드를 클릭해 불러온 결과'
+                ? 'Chart.js · /api/prices/search 결과'
                 : '품목을 선택해 주세요'}
             </span>
           </div>
           <div className={styles.cardBody}>
             {selectedTrendItem == null ? (
-              <div className={styles.emptyState}>차트 포인트나 가격 카드를 클릭하면 월별 변화를 확인할 수 있습니다.</div>
+              <div className={styles.emptyState}>차트 포인트나 가격 카드를 클릭하면 날짜별 변화를 확인할 수 있습니다.</div>
             ) : isTrendLoading ? (
-              <div className={styles.loadingState}>월별 추이 불러오는 중...</div>
+              <div className={styles.loadingState}>날짜별 추이 불러오는 중...</div>
             ) : trendError ? (
               <div className={styles.alertError}>오류: {trendError}</div>
-            ) : monthlyTrend == null ? (
-              <div className={styles.emptyState}>선택한 품목의 월별 추이 데이터가 없습니다.</div>
+            ) : dailyTrend == null || selectedTrendSeries == null ? (
+              <div className={styles.emptyState}>선택한 품목의 날짜별 추이 데이터가 없습니다.</div>
             ) : (
               <div className={styles.chartWrap}>
-                <svg
-                  aria-label="품목 월별 변화 추이"
-                  className={styles.lineChartSvg}
-                  viewBox={`0 0 ${monthlyTrend.width} ${monthlyTrend.height}`}
-                >
-                  <defs>
-                    <linearGradient id="monthly-trend-gradient" x1="0%" x2="100%" y1="0%" y2="0%">
-                      <stop offset="0%" stopColor="#2e7d32" />
-                      <stop offset="100%" stopColor="#42a5f5" />
-                    </linearGradient>
-                  </defs>
-                  <line
-                    className={styles.lineAxis}
-                    x1="40"
-                    x2={String(monthlyTrend.width - 40)}
-                    y1={String(monthlyTrend.height - monthlyTrend.paddingBottom)}
-                    y2={String(monthlyTrend.height - monthlyTrend.paddingBottom)}
+                <div className={styles.trendToolbar}>
+                  <label htmlFor="trend-series">가격 계열</label>
+                  <select
+                    id="trend-series"
+                    value={selectedTrendSeries.key}
+                    onChange={(event) => setSelectedTrendSeriesKey(event.target.value)}
+                  >
+                    {trendSeriesOptions.map((series) => (
+                      <option key={series.key} value={series.key}>
+                        {series.label} · {series.items.length}건
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className={styles.chartCanvasWrap}>
+                  <canvas
+                    ref={trendCanvasRef}
+                    aria-label={`${selectedTrendItem} 날짜별 가격 변동 차트`}
+                    className={styles.chartCanvas}
                   />
-                  <path className={styles.lineArea} d={monthlyTrend.areaPath} />
-                  <path className={styles.monthlyTrendPath} d={monthlyTrend.linePath} />
-                  {monthlyTrend.points.map((point) => (
-                    <g key={point.month}>
-                      <circle className={styles.monthlyTrendPoint} cx={point.x} cy={point.y} r="6" />
-                      <text className={styles.lineValue} x={point.x} y={point.y - 12}>
-                        {formatPrice(point.value)}
-                      </text>
-                      <text className={styles.monthlyTrendLabel} x={point.x} y={monthlyTrend.height - 12}>
-                        {point.month}
-                      </text>
-                    </g>
-                  ))}
-                </svg>
-                <div className={styles.monthlyTrendLegend}>
-                  {monthlyTrend.points.map((point) => (
-                    <div className={styles.monthlyTrendLegendItem} key={point.month}>
-                      <strong>{point.month}</strong>
-                      <p>{formatPrice(point.value)}</p>
-                    </div>
-                  ))}
                 </div>
               </div>
             )}
@@ -840,7 +938,7 @@ export default function App() {
                     </tr>
                   </thead>
                   <tbody>
-                    {priceItems.map((item) => (
+                    {visiblePriceItems.map((item) => (
                       <tr key={item.id}>
                         <td>
                           <strong>{item.itemName || '-'}</strong>
@@ -859,6 +957,17 @@ export default function App() {
                     ))}
                   </tbody>
                 </table>
+                {priceItems.length > 5 ? (
+                  <div className={styles.tableFooter}>
+                    <button
+                      className={styles.btnOutline}
+                      onClick={() => setIsPriceTableExpanded((current) => !current)}
+                      type="button"
+                    >
+                      {isPriceTableExpanded ? '접기' : `더보기 (${priceItems.length - visiblePriceItems.length}건)`}
+                    </button>
+                  </div>
+                ) : null}
               </div>
             )}
           </div>
@@ -921,6 +1030,9 @@ const styles = {
   lineLegendItem: 'lineLegendItem',
   lineLegendDot: 'lineLegendDot',
   clickablePoint: 'clickablePoint',
+  chartCanvasWrap: 'chartCanvasWrap',
+  chartCanvas: 'chartCanvas',
+  trendToolbar: 'trendToolbar',
   monthlyTrendPath: 'monthlyTrendPath',
   monthlyTrendPoint: 'monthlyTrendPoint',
   monthlyTrendLabel: 'monthlyTrendLabel',
@@ -936,6 +1048,7 @@ const styles = {
   tableCardBody: 'tableCardBody',
   tableWrap: 'tableWrap',
   table: 'table',
+  tableFooter: 'tableFooter',
   priceValue: 'priceValue',
   rankBadge: 'rankBadge',
   rankGood: 'rankGood',

--- a/front/src/styles.css
+++ b/front/src/styles.css
@@ -761,3 +761,60 @@ a:focus-visible,
     gap: 10px;
   }
 }
+
+.trendToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.trendToolbar label {
+  font-weight: 700;
+}
+
+.trendToolbar select {
+  min-width: 240px;
+  max-width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--white);
+  color: var(--text);
+}
+
+.chartCanvasWrap {
+  position: relative;
+  width: 100%;
+  min-height: 320px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fcfefe 0%, #f3f7fb 100%);
+}
+
+.chartCanvas {
+  width: 100% !important;
+  height: 280px !important;
+}
+
+@media (max-width: 800px) {
+  .trendToolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .trendToolbar select {
+    width: 100%;
+  }
+}
+
+.tableFooter {
+  display: flex;
+  justify-content: center;
+  padding: 14px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--surface2);
+}

--- a/front/src/vite-env.d.ts
+++ b/front/src/vite-env.d.ts
@@ -1,1 +1,72 @@
 /// <reference types="vite/client" />
+
+type ChartTooltipContext = {
+  dataset: { label?: string };
+  parsed: { y: number };
+};
+
+type ChartConfig = {
+  type: 'line';
+  data: {
+    labels: string[];
+    datasets: Array<{
+      label: string;
+      data: number[];
+      borderColor: string;
+      backgroundColor: string;
+      fill: boolean;
+      tension: number;
+      pointBackgroundColor: string;
+      pointBorderColor: string;
+      pointBorderWidth: number;
+      pointRadius: number;
+    }>;
+  };
+  options: {
+    responsive: boolean;
+    maintainAspectRatio: boolean;
+    interaction: {
+      intersect: boolean;
+      mode: 'index';
+    };
+    plugins: {
+      legend: {
+        display: boolean;
+        position: 'top';
+      };
+      tooltip: {
+        callbacks: {
+          label: (context: ChartTooltipContext) => string;
+        };
+      };
+    };
+    scales: {
+      x: {
+        title: {
+          display: boolean;
+          text: string;
+        };
+      };
+      y: {
+        beginAtZero: boolean;
+        title: {
+          display: boolean;
+          text: string;
+        };
+        ticks: {
+          callback: (value: string | number) => string;
+        };
+      };
+    };
+  };
+};
+
+type ChartInstance = {
+  destroy: () => void;
+};
+
+type ChartConstructor = new (context: CanvasRenderingContext2D, config: ChartConfig) => ChartInstance;
+
+interface Window {
+  Chart?: ChartConstructor;
+}

--- a/infra/jpa/src/main/java/com/repository/JpaPriceDataRepository.java
+++ b/infra/jpa/src/main/java/com/repository/JpaPriceDataRepository.java
@@ -12,5 +12,5 @@ public interface JpaPriceDataRepository extends JpaRepository<PriceData, Long> {
 
   List<PriceData> findAllByItemNameContainingIgnoreCaseOrderByCreatedAtDescIdDesc(String itemName);
 
-  List<PriceData> findAllByOrderByCreatedAtDescIdDesc(Pageable pageable);
+  List<PriceData> findAllByOrderByRegDayDescCreatedAtDescIdDesc(Pageable pageable);
 }

--- a/infra/jpa/src/main/java/com/repository/PriceDataRepositoryImpl.java
+++ b/infra/jpa/src/main/java/com/repository/PriceDataRepositoryImpl.java
@@ -37,6 +37,6 @@ public class PriceDataRepositoryImpl implements PriceDataRepository {
     if (limit <= 0) {
       return List.of();
     }
-    return repository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, limit));
+    return repository.findAllByOrderByRegDayDescCreatedAtDescIdDesc(PageRequest.of(0, limit));
   }
 }


### PR DESCRIPTION
## 요약
- Chart.js CDN 기반으로 품목별 날짜 가격 추이 라인 차트를 추가했습니다.
- `/api/prices/search?itemName=...` 결과를 계열별로 구분해 도매/소매, 품종, 등급, 단위별 추이를 선택할 수 있게 했습니다.
- 최신 데이터 조회 기준을 생성 시각이 아니라 `regDay` 기준으로 변경했습니다.

## 변경 사항
- 프론트 메인 화면에 Chart.js 날짜별 추이 차트 추가
- 가격 계열 선택 UI 추가 및 카테고리 변경 시 추이 상태 초기화
- 가격 목록 기본 5건 표시와 더보기/접기 처리
- `/api/prices/latest` 정렬 기준을 `regDay DESC, createdAt DESC, id DESC`로 변경
- 최신 데이터 정렬 기준 회귀 테스트 보강

## 검증
- `cd front && npm run build`
- `./gradlew :infra:jpa:compileJava :apps:dragons_api:test --tests com.dragons.interfaces.api.ApiControllerTest`

Closes #20


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 가격 트렌드 시각화를 월별에서 일별 차트로 개선했습니다.
  * 가격 목록 테이블에 접기/펼치기 기능이 추가되었습니다. (5개 항목 이상일 경우 "더보기/접기" 버튼 표시)

* **Tests**
  * API 엔드포인트 테스트 케이스를 업데이트했습니다.

* **Chores**
  * 차트 라이브러리 통합 및 타입 정의를 추가했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asqwklop12/dragons_batch/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->